### PR TITLE
Fix wording adjustments

### DIFF
--- a/src/Widgets/button.test.tsx
+++ b/src/Widgets/button.test.tsx
@@ -60,15 +60,15 @@ describe('Button', () => {
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('1 x 124,52 € puis 3 x 112,50 €')).toBeInTheDocument()
+      expect(screen.getByText('124,52 € puis 3 x 112,50 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText(/1 x 47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
+      expect(screen.getByText(/47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
@@ -120,11 +120,11 @@ describe('Button', () => {
       act(() => {
         fireEvent.mouseEnter(screen.getByText('3x'))
       })
-      expect(screen.getByText(/1 x 151,35 € puis 2 x 150,00 €/)).toBeInTheDocument()
+      expect(screen.getByText(/151,35 € puis 2 x 150,00 €/)).toBeInTheDocument()
       act(() => {
         fireEvent.mouseEnter(screen.getByText('10x'))
       })
-      expect(screen.getByText(/1 x 47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
+      expect(screen.getByText(/47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
@@ -133,12 +133,12 @@ describe('Button', () => {
       act(() => {
         fireEvent.mouseEnter(screen.getByText('3x'))
       })
-      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
 
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
     })
   })
   describe('paymentPlan includes contains ineligible options', () => {
@@ -188,11 +188,11 @@ describe('Button', () => {
       expect(screen.queryByText('8x')).not.toBeInTheDocument()
     })
     it('Only iterates over active plans', () => {
-      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
     })
     it('display conditions when inactive plans are hovered', () => {
       act(() => {
@@ -227,15 +227,15 @@ describe('Button', () => {
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText('1 x 124,52 € puis 3 x 112,50 €')).toBeInTheDocument()
+      expect(screen.getByText('124,52 € puis 3 x 112,50 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText(/1 x 47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
+      expect(screen.getByText(/47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
@@ -300,7 +300,7 @@ describe('Button', () => {
       act(() => {
         fireEvent.mouseEnter(screen.getByText('3x'))
       })
-      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       act(() => {
         fireEvent.click(screen.getByTestId('widget-button'))
       })
@@ -324,7 +324,7 @@ describe('Button', () => {
       act(() => {
         fireEvent.click(screen.getByText('3x'))
       })
-      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       expect(screen.getByTestId('modal-close-button')).toBeInTheDocument()
       const modalContainer = screen.getByTestId('modal-container')
       expect(within(modalContainer).getByText('21 octobre 2021')).toBeInTheDocument()

--- a/src/Widgets/button.test.tsx
+++ b/src/Widgets/button.test.tsx
@@ -50,11 +50,13 @@ describe('Button', () => {
       expect(screen.getByText('4x')).toBeInTheDocument()
     })
     it(`display iterates on each message every ${animationDuration} ms then returns to the beginning`, () => {
-      expect(screen.getByText('450,00 € à payer le 21 novembre 2021')).toBeInTheDocument()
+      expect(screen.getByText(/450,00 € à payer le 21 novembre 2021/)).toBeInTheDocument()
+      expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('2 x 225,00 €')).toBeInTheDocument()
+      expect(screen.getByText(/2 x 225,00 €/)).toBeInTheDocument()
+      expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
@@ -66,11 +68,12 @@ describe('Button', () => {
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('1 x 47,73 € puis 9 x 47,66 €')).toBeInTheDocument()
+      expect(screen.getByText(/1 x 47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('450,00 € à payer le 21 novembre 2021')).toBeInTheDocument()
+      expect(screen.getByText(/450,00 € à payer le 21 novembre 2021/)).toBeInTheDocument()
+      expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
     })
   })
   describe('paymentPlan includes credit', () => {
@@ -112,15 +115,16 @@ describe('Button', () => {
       await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
     })
     it('displays the message corresponding to the payment plan hovered', () => {
-      expect(screen.getByText('450,00 € à payer le 21 novembre 2021')).toBeInTheDocument()
+      expect(screen.getByText(/450,00 € à payer le 21 novembre 2021/)).toBeInTheDocument()
+      expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
       act(() => {
         fireEvent.mouseEnter(screen.getByText('3x'))
       })
-      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText(/1 x 151,35 € puis 2 x 150,00 €/)).toBeInTheDocument()
       act(() => {
         fireEvent.mouseEnter(screen.getByText('10x'))
       })
-      expect(screen.getByText('1 x 47,73 € puis 9 x 47,66 €')).toBeInTheDocument()
+      expect(screen.getByText(/1 x 47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
@@ -213,11 +217,13 @@ describe('Button', () => {
       await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
     })
     it(`display iterates on each message every 500 ms then returns to the beginning`, () => {
-      expect(screen.getByText('450,00 € à payer le 21 novembre 2021')).toBeInTheDocument()
+      expect(screen.getByText(/450,00 € à payer le 21 novembre 2021/)).toBeInTheDocument()
+      expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText('2 x 225,00 €')).toBeInTheDocument()
+      expect(screen.getByText(/2 x 225,00 €/)).toBeInTheDocument()
+      expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
@@ -229,11 +235,12 @@ describe('Button', () => {
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText('1 x 47,73 € puis 9 x 47,66 €')).toBeInTheDocument()
+      expect(screen.getByText(/1 x 47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText('450,00 € à payer le 21 novembre 2021')).toBeInTheDocument()
+      expect(screen.getByText(/450,00 € à payer le 21 novembre 2021/)).toBeInTheDocument()
+      expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
     })
   })
   describe('hide if not applicable', () => {
@@ -337,7 +344,8 @@ describe('Button', () => {
       act(() => {
         fireEvent.click(screen.getByTestId('widget-button'))
       })
-      expect(screen.getByText('450,00 € à payer le 21 novembre 2021')).toBeInTheDocument()
+      expect(screen.getByText(/450,00 € à payer le 21 novembre 2021/)).toBeInTheDocument()
+      expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
       expect(screen.getByTestId('modal-close-button')).toBeInTheDocument()
       const modalContainer = screen.getByTestId('modal-container')
       expect(within(modalContainer).getByText('21 novembre 2021')).toBeInTheDocument()

--- a/src/Widgets/button.test.tsx
+++ b/src/Widgets/button.test.tsx
@@ -54,19 +54,19 @@ describe('Button', () => {
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('2 mensualités de 225,00 €')).toBeInTheDocument()
+      expect(screen.getByText('2 x 225,00 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('151,35 € puis 2 mensualités de 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('124,52 € puis 3 mensualités de 112,50 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 124,52 € puis 3 x 112,50 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('47,73 € puis 9 mensualités de 47,66 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 47,73 € puis 9 x 47,66 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
@@ -116,11 +116,11 @@ describe('Button', () => {
       act(() => {
         fireEvent.mouseEnter(screen.getByText('3x'))
       })
-      expect(screen.getByText('151,35 € puis 2 mensualités de 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       act(() => {
         fireEvent.mouseEnter(screen.getByText('10x'))
       })
-      expect(screen.getByText('47,73 € puis 9 mensualités de 47,66 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 47,73 € puis 9 x 47,66 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
@@ -129,12 +129,12 @@ describe('Button', () => {
       act(() => {
         fireEvent.mouseEnter(screen.getByText('3x'))
       })
-      expect(screen.getByText('151,35 € puis 2 mensualités de 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
 
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('151,35 € puis 2 mensualités de 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
     })
   })
   describe('paymentPlan includes contains ineligible options', () => {
@@ -184,11 +184,11 @@ describe('Button', () => {
       expect(screen.queryByText('8x')).not.toBeInTheDocument()
     })
     it('Only iterates over active plans', () => {
-      expect(screen.getByText('151,35 € puis 2 mensualités de 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(animationDuration)
       })
-      expect(screen.getByText('151,35 € puis 2 mensualités de 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
     })
     it('display conditions when inactive plans are hovered', () => {
       act(() => {
@@ -217,19 +217,19 @@ describe('Button', () => {
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText('2 mensualités de 225,00 €')).toBeInTheDocument()
+      expect(screen.getByText('2 x 225,00 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText('151,35 € puis 2 mensualités de 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText('124,52 € puis 3 mensualités de 112,50 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 124,52 € puis 3 x 112,50 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
-      expect(screen.getByText('47,73 € puis 9 mensualités de 47,66 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 47,73 € puis 9 x 47,66 €')).toBeInTheDocument()
       act(() => {
         jest.advanceTimersByTime(500)
       })
@@ -293,7 +293,7 @@ describe('Button', () => {
       act(() => {
         fireEvent.mouseEnter(screen.getByText('3x'))
       })
-      expect(screen.getByText('151,35 € puis 2 mensualités de 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       act(() => {
         fireEvent.click(screen.getByTestId('widget-button'))
       })
@@ -317,7 +317,7 @@ describe('Button', () => {
       act(() => {
         fireEvent.click(screen.getByText('3x'))
       })
-      expect(screen.getByText('151,35 € puis 2 mensualités de 150,00 €')).toBeInTheDocument()
+      expect(screen.getByText('1 x 151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
       expect(screen.getByTestId('modal-close-button')).toBeInTheDocument()
       const modalContainer = screen.getByTestId('modal-container')
       expect(within(modalContainer).getByText('21 octobre 2021')).toBeInTheDocument()

--- a/src/intl/messages.json
+++ b/src/intl/messages.json
@@ -15,5 +15,6 @@
   "payment-plan-strings.ineligible-greater-than-max": "Jusqu'à {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "À partir de {minAmount}",
   "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
+  "payment-plan-strings.no-fee": "(sans frais)"
 }

--- a/src/intl/messages.json
+++ b/src/intl/messages.json
@@ -14,6 +14,6 @@
   "payment-plan-strings.deferred": "{totalAmount} à payer le {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Jusqu'à {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "À partir de {minAmount}",
-  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} puis {numberOfRemainingInstallments, plural, one {# mensualité} other {# mensualités}} de {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} mensualités de {totalAmount}"
+  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
 }

--- a/src/intl/messages.json
+++ b/src/intl/messages.json
@@ -14,7 +14,7 @@
   "payment-plan-strings.deferred": "{totalAmount} à payer le {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Jusqu'à {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "À partir de {minAmount}",
-  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(sans frais)"
 }

--- a/src/intl/messages/messages.de.json
+++ b/src/intl/messages/messages.de.json
@@ -14,6 +14,6 @@
   "payment-plan-strings.deferred": "{totalAmount} zu zahlen am {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Bis zu {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Ab {minAmount}",
-  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} dann {numberOfRemainingInstallments, plural, one {# Monatsrate} other {# Monatsraten}} von {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} Monatsraten von {totalAmount}"
+  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} dann {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
 }

--- a/src/intl/messages/messages.de.json
+++ b/src/intl/messages/messages.de.json
@@ -14,7 +14,7 @@
   "payment-plan-strings.deferred": "{totalAmount} zu zahlen am {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Bis zu {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Ab {minAmount}",
-  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} dann {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} dann {numberOfRemainingInstallments} x {othersInstallmentAmount}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(gebührenfrei)"
 }

--- a/src/intl/messages/messages.de.json
+++ b/src/intl/messages/messages.de.json
@@ -15,5 +15,6 @@
   "payment-plan-strings.ineligible-greater-than-max": "Bis zu {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Ab {minAmount}",
   "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} dann {numberOfRemainingInstallments} x {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
+  "payment-plan-strings.no-fee": "(gebührenfrei)"
 }

--- a/src/intl/messages/messages.en.json
+++ b/src/intl/messages/messages.en.json
@@ -14,7 +14,7 @@
   "payment-plan-strings.deferred": "{totalAmount} to be paid on {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Until {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "From {minAmount}",
-  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} then {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} then {numberOfRemainingInstallments} x {othersInstallmentAmount}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(free of charge)"
 }

--- a/src/intl/messages/messages.en.json
+++ b/src/intl/messages/messages.en.json
@@ -14,6 +14,6 @@
   "payment-plan-strings.deferred": "{totalAmount} to be paid on {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Until {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "From {minAmount}",
-  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} then {numberOfRemainingInstallments, plural, one {# monthly installment} other {# monthly installment}} of {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} monthly installments of {totalAmount}"
+  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} then {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
 }

--- a/src/intl/messages/messages.en.json
+++ b/src/intl/messages/messages.en.json
@@ -15,5 +15,6 @@
   "payment-plan-strings.ineligible-greater-than-max": "Until {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "From {minAmount}",
   "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} then {numberOfRemainingInstallments} x {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
+  "payment-plan-strings.no-fee": "(free of charge)"
 }

--- a/src/intl/messages/messages.es.json
+++ b/src/intl/messages/messages.es.json
@@ -15,5 +15,6 @@
   "payment-plan-strings.ineligible-greater-than-max": "Hasta {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Desde {minAmount}",
   "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} entonces {numberOfRemainingInstallments} x {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
+  "payment-plan-strings.no-fee": "(gratis)"
 }

--- a/src/intl/messages/messages.es.json
+++ b/src/intl/messages/messages.es.json
@@ -14,7 +14,7 @@
   "payment-plan-strings.deferred": "{totalAmount} a pagar el {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Hasta {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Desde {minAmount}",
-  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} entonces {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} entonces {numberOfRemainingInstallments} x {othersInstallmentAmount}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(gratis)"
 }

--- a/src/intl/messages/messages.es.json
+++ b/src/intl/messages/messages.es.json
@@ -14,6 +14,6 @@
   "payment-plan-strings.deferred": "{totalAmount} a pagar el {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Hasta {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Desde {minAmount}",
-  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} después {numberOfRemainingInstallments, plural, one {#mensualidad} other {# mensualidades}} de {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} cuotas mensuales de {totalAmount}"
+  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} entonces {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
 }

--- a/src/intl/messages/messages.fr.json
+++ b/src/intl/messages/messages.fr.json
@@ -15,5 +15,6 @@
   "payment-plan-strings.ineligible-greater-than-max": "Jusqu'à {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "À partir de {minAmount}",
   "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
+  "payment-plan-strings.no-fee": "(sans frais)"
 }

--- a/src/intl/messages/messages.fr.json
+++ b/src/intl/messages/messages.fr.json
@@ -14,6 +14,6 @@
   "payment-plan-strings.deferred": "{totalAmount} à payer le {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Jusqu'à {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "À partir de {minAmount}",
-  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} puis {numberOfRemainingInstallments, plural, one {# mensualité} other {# mensualités}} de {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} mensualités de {totalAmount}"
+  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
 }

--- a/src/intl/messages/messages.fr.json
+++ b/src/intl/messages/messages.fr.json
@@ -14,7 +14,7 @@
   "payment-plan-strings.deferred": "{totalAmount} à payer le {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Jusqu'à {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "À partir de {minAmount}",
-  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(sans frais)"
 }

--- a/src/intl/messages/messages.it.json
+++ b/src/intl/messages/messages.it.json
@@ -15,5 +15,6 @@
   "payment-plan-strings.ineligible-greater-than-max": "Fino a {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Da {minAmount}",
   "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} allora {numberOfRemainingInstallments} x {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
+  "payment-plan-strings.no-fee": "(gratuito)"
 }

--- a/src/intl/messages/messages.it.json
+++ b/src/intl/messages/messages.it.json
@@ -14,7 +14,7 @@
   "payment-plan-strings.deferred": "{totalAmount} da pagare su {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Fino a {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Da {minAmount}",
-  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} allora {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} allora {numberOfRemainingInstallments} x {othersInstallmentAmount}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(gratuito)"
 }

--- a/src/intl/messages/messages.it.json
+++ b/src/intl/messages/messages.it.json
@@ -14,6 +14,6 @@
   "payment-plan-strings.deferred": "{totalAmount} da pagare su {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Fino a {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Da {minAmount}",
-  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} allora {numberOfRemainingInstallments, plural, one {# rate mensili} other {# rate mensili}} di {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} rate mensili di {totalAmount}"
+  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} allora {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
 }

--- a/src/intl/messages/messages.nl.json
+++ b/src/intl/messages/messages.nl.json
@@ -15,5 +15,6 @@
   "payment-plan-strings.ineligible-greater-than-max": "Tot {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Van {minAmount}",
   "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} dan {numberOfRemainingInstallments} x {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
+  "payment-plan-strings.no-fee": "(gratis)"
 }

--- a/src/intl/messages/messages.nl.json
+++ b/src/intl/messages/messages.nl.json
@@ -14,7 +14,7 @@
   "payment-plan-strings.deferred": "{totalAmount} te betalen op {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Tot {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Van {minAmount}",
-  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} dan {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} dan {numberOfRemainingInstallments} x {othersInstallmentAmount}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(gratis)"
 }

--- a/src/intl/messages/messages.nl.json
+++ b/src/intl/messages/messages.nl.json
@@ -14,6 +14,6 @@
   "payment-plan-strings.deferred": "{totalAmount} te betalen op {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Tot {maxAmount}",
   "payment-plan-strings.ineligible-lower-than-min": "Van {minAmount}",
-  "payment-plan-strings.multiple-installments": "{firstInstallmentAmount} dan {numberOfRemainingInstallments, plural, one {# maandelijkse termijnen} other {# maandelijkse termijnen}} van {othersInstallmentAmount}",
-  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} maandelijkse termijnen van {totalAmount}"
+  "payment-plan-strings.multiple-installments": "1 x {firstInstallmentAmount} dan {numberOfRemainingInstallments} x {othersInstallmentAmount}",
+  "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}"
 }

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -91,7 +91,7 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
       return (
         <FormattedMessage
           id="payment-plan-strings.multiple-installments-same-amount"
-          defaultMessage="{installmentsCount} mensualités de {totalAmount}"
+          defaultMessage="{installmentsCount} x {totalAmount}"
           values={{
             totalAmount: (
               <FormattedNumber
@@ -109,7 +109,7 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
     return (
       <FormattedMessage
         id="payment-plan-strings.multiple-installments"
-        defaultMessage="{firstInstallmentAmount} puis {numberOfRemainingInstallments, plural, one {# mensualité} other {# mensualités}} de {othersInstallmentAmount}"
+        defaultMessage="1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}"
         values={{
           firstInstallmentAmount: (
             <FormattedNumber

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -35,6 +35,19 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
   } = payment
   const deferredDaysCount = deferred_days + deferred_months * 30
 
+  const withNoFee = () => {
+    if (
+      payment.payment_plan.every((plan) => plan.customer_fee === 0 && plan.customer_interest === 0)
+    ) {
+      return (
+        <>
+          {' '}
+          <FormattedMessage id="payment-plan-strings.no-fee" defaultMessage={'(sans frais)'} />
+        </>
+      )
+    }
+  }
+
   if (!eligible) {
     return purchaseAmount > maxAmount ? (
       <FormattedMessage
@@ -59,27 +72,30 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
     )
   } else if (deferredDaysCount !== 0 && installmentsCount === 1) {
     return (
-      <FormattedMessage
-        id="payment-plan-strings.deferred"
-        defaultMessage="{totalAmount} à payer le {dueDate}"
-        values={{
-          totalAmount: (
-            <FormattedNumber
-              value={priceFromCents(payment.payment_plan[0].total_amount)}
-              style="currency"
-              currency="EUR"
-            />
-          ),
-          dueDate: (
-            <FormattedDate
-              value={secondsToMilliseconds(payment.payment_plan[0].due_date)}
-              day="numeric"
-              month="long"
-              year="numeric"
-            />
-          ),
-        }}
-      />
+      <>
+        <FormattedMessage
+          id="payment-plan-strings.deferred"
+          defaultMessage="{totalAmount} à payer le {dueDate}"
+          values={{
+            totalAmount: (
+              <FormattedNumber
+                value={priceFromCents(payment.payment_plan[0].total_amount)}
+                style="currency"
+                currency="EUR"
+              />
+            ),
+            dueDate: (
+              <FormattedDate
+                value={secondsToMilliseconds(payment.payment_plan[0].due_date)}
+                day="numeric"
+                month="long"
+                year="numeric"
+              />
+            ),
+          }}
+        />
+        {withNoFee()}
+      </>
     )
   } else if (installmentsCount > 0) {
     const areInstallmentsOfSameAmount = payment.payment_plan.every(
@@ -89,45 +105,51 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
 
     if (areInstallmentsOfSameAmount) {
       return (
+        <>
+          <FormattedMessage
+            id="payment-plan-strings.multiple-installments-same-amount"
+            defaultMessage="{installmentsCount} x {totalAmount}"
+            values={{
+              totalAmount: (
+                <FormattedNumber
+                  value={priceFromCents(payment.payment_plan[0].total_amount)}
+                  style="currency"
+                  currency="EUR"
+                />
+              ),
+              installmentsCount,
+            }}
+          />
+          {withNoFee()}
+        </>
+      )
+    }
+
+    return (
+      <>
         <FormattedMessage
-          id="payment-plan-strings.multiple-installments-same-amount"
-          defaultMessage="{installmentsCount} x {totalAmount}"
+          id="payment-plan-strings.multiple-installments"
+          defaultMessage="1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}"
           values={{
-            totalAmount: (
+            firstInstallmentAmount: (
               <FormattedNumber
                 value={priceFromCents(payment.payment_plan[0].total_amount)}
                 style="currency"
                 currency="EUR"
               />
             ),
-            installmentsCount,
+            numberOfRemainingInstallments: installmentsCount - 1,
+            othersInstallmentAmount: (
+              <FormattedNumber
+                value={priceFromCents(payment.payment_plan[1].total_amount)}
+                style="currency"
+                currency="EUR"
+              />
+            ),
           }}
         />
-      )
-    }
-
-    return (
-      <FormattedMessage
-        id="payment-plan-strings.multiple-installments"
-        defaultMessage="1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}"
-        values={{
-          firstInstallmentAmount: (
-            <FormattedNumber
-              value={priceFromCents(payment.payment_plan[0].total_amount)}
-              style="currency"
-              currency="EUR"
-            />
-          ),
-          numberOfRemainingInstallments: installmentsCount - 1,
-          othersInstallmentAmount: (
-            <FormattedNumber
-              value={priceFromCents(payment.payment_plan[1].total_amount)}
-              style="currency"
-              currency="EUR"
-            />
-          ),
-        }}
-      />
+        {withNoFee()}
+      </>
     )
   }
   return (

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -129,7 +129,7 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
       <>
         <FormattedMessage
           id="payment-plan-strings.multiple-installments"
-          defaultMessage="1 x {firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}"
+          defaultMessage="{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}"
           values={{
             firstInstallmentAmount: (
               <FormattedNumber


### PR DESCRIPTION
Story : https://app.clickup.com/t/20427503/AL-209

We needed to adjust wording and translation

File change : `paymentPlanStrings.tsx` 

- We replaced each "{installmentsCount} mensualités de {totalAmount}"  by "{installmentsCount} x {totalAmount}"
- We created a function that returns "(sans frais)" if there are no fee or interests