### PR TITLE
Handle not eligible plans from dashboard's config

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -100,6 +100,8 @@
             <select onchange="renderPaymentPlans()" id="quantity">
               <option value="1">1</option>
               <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="10">10</option>
             </select>
             <h3>450 €</h3>
             <div id="alma-widget-payment-plans"></div>
@@ -120,9 +122,9 @@
 
     <script>
       var widgets = Alma.Widgets.initialize('11gKoO333vEXacMNMUMUSc4c4g68g2Les4', Alma.ApiMode.TEST)
-      var purchaseAmount = 450 * 100 * document.getElementById('quantity').value
 
       function renderPaymentPlans() {
+        var purchaseAmount = 450 * 100 * document.getElementById('quantity').value
         widgets.add(Alma.Widgets.PaymentPlans, {
           container: '#alma-widget-payment-plans',
           purchaseAmount,
@@ -137,10 +139,11 @@
               minAmount: 5000,
               maxAmount: 90000,
             },
+
             {
               installmentsCount: 2,
               minAmount: 5000,
-              maxAmount: 9000,
+              maxAmount: 90000,
             },
             {
               installmentsCount: 4,
@@ -149,8 +152,8 @@
             },
             {
               installmentsCount: 10,
-              minAmount: 5000,
-              maxAmount: 90000,
+              minAmount: 45000,
+              maxAmount: 800000,
             },
           ],
         })
@@ -158,6 +161,7 @@
       renderPaymentPlans()
 
       function renderModal() {
+        var purchaseAmount = 450 * 100 * document.getElementById('quantity').value
         return widgets.add(Alma.Widgets.Modal, {
           container: '#alma-widget-modal',
           clickableSelector: '#alma-open-modal-button',

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ const path = require('path')
 module.exports = {
   moduleDirectories: ['node_modules', path.join(__dirname, 'src')],
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  testPathIgnorePatterns: ['<rootDir>/dist/'],
 }

--- a/src/Widgets/PaymentPlans/__tests__/IneligibleOptions.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/IneligibleOptions.test.tsx
@@ -1,45 +1,40 @@
-import { act, screen, waitFor, fireEvent } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { ApiMode } from 'consts'
 import React from 'react'
 import render from 'test'
+import { mockEligibilityPaymentPlanWithIneligiblePlan } from 'test/fixtures'
 import PaymentPlanWidget from '..'
-import { mockButtonPlans } from 'test/fixtures'
 
 jest.mock('utils/fetch', () => {
   return {
-    fetchFromApi: async () => mockButtonPlans,
+    fetchFromApi: async () => mockEligibilityPaymentPlanWithIneligiblePlan,
   }
 })
 jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01').getTime())
 
 const animationDuration = 5600
 
-describe('PaymentPlan has ineligible options', () => {
+describe('PaymentPlan has ineligible options from configPlans', () => {
   beforeEach(async () => {
     render(
       <PaymentPlanWidget
-        purchaseAmount={40000}
+        purchaseAmount={45000}
         configPlans={[
           {
             installmentsCount: 1,
+            deferredDays: 30,
             minAmount: 5000,
-            maxAmount: 20000,
+            maxAmount: 70000,
           },
           {
             installmentsCount: 2,
             minAmount: 5000,
-            maxAmount: 20000,
-          },
-          {
-            installmentsCount: 1,
-            deferredDays: 30,
-            minAmount: 50000,
-            maxAmount: 70000,
-          },
-          {
-            installmentsCount: 3,
-            minAmount: 5000,
             maxAmount: 50000,
+          },
+          {
+            installmentsCount: 4,
+            minAmount: 5000,
+            maxAmount: 15000,
           },
           {
             installmentsCount: 8,
@@ -55,7 +50,7 @@ describe('PaymentPlan has ineligible options', () => {
 
   it('displays only provided plans (except p1x)', () => {
     expect(screen.getByText('J+30')).toBeInTheDocument()
-    expect(screen.getByText('3x')).toBeInTheDocument()
+    expect(screen.getByText('4x')).toBeInTheDocument()
     expect(screen.queryByText('1x')).not.toBeInTheDocument()
   })
 
@@ -63,22 +58,47 @@ describe('PaymentPlan has ineligible options', () => {
     expect(screen.queryByText('8x')).not.toBeInTheDocument()
   })
 
-  it('only iterates over active plans', () => {
-    expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+  it('only iterates over active plans', async () => {
+    expect(screen.getByText('450,00 € à payer le 3 juin 2022 (sans frais)')).toBeInTheDocument()
     act(() => {
       jest.advanceTimersByTime(animationDuration)
     })
-    expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
+    expect(screen.getByText('2 x 225,00 € (sans frais)')).toBeInTheDocument()
   })
 
   it('display conditions when inactive plans are hovered', () => {
-    act(() => {
-      fireEvent.mouseEnter(screen.getByText('J+30'))
-    })
-    expect(screen.getByText('À partir de 500,00 €')).toBeInTheDocument()
-    act(() => {
-      fireEvent.mouseEnter(screen.getByText('2x'))
-    })
+    fireEvent.mouseEnter(screen.getByText('4x'))
+    expect(screen.getByText("Jusqu'à 150,00 €")).toBeInTheDocument()
+  })
+})
+
+describe('PaymentPlan has ineligible options from merchant config', () => {
+  beforeEach(async () => {
+    render(
+      <PaymentPlanWidget
+        purchaseAmount={45000}
+        configPlans={[
+          {
+            installmentsCount: 4,
+            minAmount: 30000,
+            maxAmount: 400000,
+          },
+          {
+            installmentsCount: 10,
+            minAmount: 5000,
+            maxAmount: 50000,
+          },
+        ]}
+        apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
+      />,
+    )
+    await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
+  })
+
+  it('display conditions when non eligible plans are hovered', () => {
+    fireEvent.mouseEnter(screen.getByText('10x'))
+    expect(screen.getByText('À partir de 900,00 €')).toBeInTheDocument()
+    fireEvent.mouseEnter(screen.getByText('4x'))
     expect(screen.getByText("Jusqu'à 200,00 €")).toBeInTheDocument()
   })
 })

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,5 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect'
+
+jest.mock('no-scroll', () => ({ on: jest.fn(), off: jest.fn() }))

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -453,3 +453,71 @@ export const mockButtonPlans = [
     purchase_amount: 45000,
   },
 ]
+
+export const mockEligibilityPaymentPlanWithIneligiblePlan = [
+  {
+    customer_fee: 0,
+    customer_interest: 0,
+    customer_total_cost_amount: 0,
+    customer_total_cost_bps: 0,
+    deferred_days: 30,
+    deferred_months: 0,
+    eligible: true,
+    installments_count: 1,
+    payment_plan: [
+      {
+        customer_fee: 0,
+        customer_interest: 0,
+        due_date: 1654262242,
+        purchase_amount: 45000,
+        total_amount: 45000,
+      },
+    ],
+    purchase_amount: 45000,
+  },
+  {
+    customer_fee: 0,
+    customer_interest: 0,
+    customer_total_cost_amount: 0,
+    customer_total_cost_bps: 0,
+    deferred_days: 0,
+    deferred_months: 0,
+    eligible: true,
+    installments_count: 2,
+    payment_plan: [
+      {
+        customer_fee: 0,
+        customer_interest: 0,
+        due_date: 1651670242,
+        purchase_amount: 22500,
+        total_amount: 22500,
+      },
+      {
+        customer_fee: 0,
+        customer_interest: 0,
+        due_date: 1654348642,
+        purchase_amount: 22500,
+        total_amount: 22500,
+      },
+    ],
+    purchase_amount: 45000,
+  },
+  {
+    constraints: { purchase_amount: { maximum: 20000, minimum: 9000 } },
+    deferred_days: 0,
+    deferred_months: 0,
+    eligible: false,
+    installments_count: 4,
+    purchase_amount: 45000,
+    reasons: { purchase_amount: 'invalid_value' },
+  },
+  {
+    constraints: { purchase_amount: { maximum: 135000, minimum: 90000 } },
+    deferred_days: 0,
+    deferred_months: 0,
+    eligible: false,
+    installments_count: 10,
+    purchase_amount: 45000,
+    reasons: { purchase_amount: 'invalid_value' },
+  },
+]

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,9 +37,13 @@ export type EligibilityPlan = {
   eligible: boolean
   reasons?: Record<string, unknown>
   installments_count: number
-  payment_plan: PaymentPlan[]
+  payment_plan?: PaymentPlan[]
   purchase_amount: number
+  constraints?: {
+    purchase_amount?: { minimum: number; maximum: number }
+  }
 }
+
 export type EligibilityPlanToDisplay = EligibilityPlan & {
   minAmount?: number
   maxAmount?: number

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "jsx": "react",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
   },
-  "include": ["src", "node_modules/microbundle/index.d.ts"]
+  "include": ["src", "node_modules/microbundle/index.d.ts"],
+  "exclude": ["**/*.test.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,5 @@
     "jsx": "react",
     "resolveJsonModule": true,
   },
-  "include": ["src", "node_modules/microbundle/index.d.ts"],
-  "exclude": ["**/*.test.tsx"]
+  "include": ["src", "node_modules/microbundle/index.d.ts"]
 }


### PR DESCRIPTION
We were only handling min and max from merchant's configPlan given to the widget, we now also handle min and max from dashboard's config.

![bitmoji](https://sdk.bitmoji.com/render/panel/f50cb849-9852-47ad-8b18-2a5d0dabce99-1731a188-ea16-49c3-83c0-aa3f8979e7dd-v1.png?transparent=1&palette=1&width=246)