### PR TITLE
feat: add "monochrome" option to the widgets

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -48,7 +48,7 @@ The amount of time in between button animations in ms.
 
 - hideIfNotEligible: `boolean` [optional, default: false]
 
-Totally hide the widget if set to true and no plan matches the purchase amount.
+Totally hides the widget if set to true and no plan matches the purchase amount.
 
 - suggestedPaymentPlan: `number` | `number[]` [optional]
 

--- a/src/Widgets/PaymentPlans/PaymentPlans.module.css
+++ b/src/Widgets/PaymentPlans/PaymentPlans.module.css
@@ -48,6 +48,10 @@
   border-bottom: 3px solid var(--blue-300);
 }
 
+.plan.active.polychrome {
+  border-bottom-color: var(--red-600);
+}
+
 .plan.active.notEligible {
   border-bottom-color: var(--gray-600);
   cursor: not-allowed;

--- a/src/Widgets/PaymentPlans/__tests__/Monochrome.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/Monochrome.test.tsx
@@ -1,0 +1,33 @@
+import { screen, waitFor } from '@testing-library/react'
+import { ApiMode } from 'consts'
+import React from 'react'
+import render from 'test'
+import PaymentPlanWidget from '..'
+import { mockButtonPlans } from 'test/fixtures'
+
+jest.mock('utils/fetch', () => {
+  return {
+    fetchFromApi: async () => mockButtonPlans,
+  }
+})
+
+it.each([true, false])(
+  'renders the monochrome version of the widget when expected',
+  async (monochrome) => {
+    render(
+      <PaymentPlanWidget
+        purchaseAmount={40000}
+        apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
+        monochrome={monochrome}
+      />,
+    )
+    await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
+    expect(screen.getByTestId('widget-button')).toBeInTheDocument()
+    expect(screen.getByText('J+30').className).toContain('active')
+    if (monochrome) {
+      expect(screen.getByText('J+30').className).not.toContain('polychrome')
+    } else {
+      expect(screen.getByText('J+30').className).toContain('polychrome')
+    }
+  },
+)

--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -17,6 +17,7 @@ type Props = {
   configPlans?: ConfigPlan[]
   transitionDelay?: number
   hideIfNotEligible?: boolean
+  monochrome: boolean
   suggestedPaymentPlan?: number | number[]
   cards?: Card[]
 }
@@ -25,13 +26,14 @@ const VERY_LONG_TIME_IN_MS = 1000 * 3600 * 24 * 365
 const DEFAULT_TRANSITION_TIME = 5500
 
 const PaymentPlanWidget: VoidFunctionComponent<Props> = ({
-  purchaseAmount,
   apiData,
   configPlans,
-  transitionDelay,
   hideIfNotEligible,
+  monochrome,
+  purchaseAmount,
   suggestedPaymentPlan,
   cards,
+  transitionDelay,
 }) => {
   const [eligibilityPlans, status] = useFetchEligibility(purchaseAmount, apiData, configPlans)
   const eligiblePlans = eligibilityPlans.filter((plan) => plan.eligible)
@@ -125,16 +127,18 @@ const PaymentPlanWidget: VoidFunctionComponent<Props> = ({
         data-testid="widget-button"
       >
         <div className={cx(s.primaryContainer, STATIC_CUSTOMISATION_CLASSES.eligibilityLine)}>
-          <LogoIcon className={s.logo} />
+          <LogoIcon className={s.logo} monochrome={monochrome} />
           <div className={cx(s.paymentPlans, STATIC_CUSTOMISATION_CLASSES.eligibilityOptions)}>
             {eligibilityPlans.map((eligibilityPlan, key) => {
+              const isCurrent = key === current
               return (
                 <div
                   key={key}
                   onMouseEnter={() => onHover(key)}
                   onMouseOut={onLeave}
                   className={cx(s.plan, {
-                    [cx(s.active, STATIC_CUSTOMISATION_CLASSES.activeOption)]: current === key,
+                    [cx(s.active, STATIC_CUSTOMISATION_CLASSES.activeOption)]: isCurrent,
+                    [s.polychrome]: !monochrome && isCurrent,
                     [cx(s.notEligible, STATIC_CUSTOMISATION_CLASSES.notEligibleOption)]:
                       !eligibilityPlan.eligible,
                   })}

--- a/src/assets/Logo.tsx
+++ b/src/assets/Logo.tsx
@@ -1,16 +1,24 @@
 import React from 'react'
 
+enum COLORS {
+  ALMA = '#FF414D',
+  MONOCHROME = '#00425D',
+}
+
 type Props = {
-  color?: string
   className?: string
+  color?: string
+  monochrome?: boolean
   underlineColor?: string
 }
 
 function LogoIcon({
-  color = '#00425D',
-  underlineColor = '#00425D',
   className,
+  color = COLORS.MONOCHROME,
+  monochrome = true,
+  underlineColor,
 }: Props): JSX.Element {
+  const defaultUnderlineColor = monochrome ? COLORS.MONOCHROME : COLORS.ALMA
   return (
     <svg
       className={className}
@@ -36,7 +44,7 @@ function LogoIcon({
         d="M37.0321 10.1313V10.029H35.572C34.885 10.029 34.3754 10.0972 34.0433 10.2337C33.7227 10.3587 33.5623 10.6374 33.5623 11.0695C33.5623 11.7177 34.0204 12.0418 34.9365 12.0418C35.7037 12.0418 36.2419 11.8826 36.5511 11.5642C36.8717 11.2344 37.0321 10.7568 37.0321 10.1313ZM34.3696 13.9182C33.2932 13.9182 32.4974 13.6567 31.9821 13.1335C31.4668 12.599 31.2091 11.911 31.2091 11.0695C31.2091 10.0574 31.5412 9.32958 32.2054 8.88606C32.8695 8.43118 33.883 8.20374 35.2457 8.20374H37.0321V7.82846C37.0321 6.98693 36.4939 6.56616 35.4174 6.56616C34.4555 6.56616 33.923 6.93007 33.82 7.65788H31.4152C31.4954 6.78223 31.8618 6.04873 32.5145 5.45738C33.1673 4.86603 34.1521 4.57036 35.469 4.57036C36.7744 4.57036 37.7592 4.86035 38.4234 5.44032C39.0876 6.0203 39.4196 6.83909 39.4196 7.89669V13.7135H37.2554V12.7241C36.7401 13.5202 35.7781 13.9182 34.3696 13.9182Z"
         fill={color}
       />
-      <rect y="20" width="40" height="3" fill={underlineColor} />
+      <rect y="20" width="40" height="3" fill={underlineColor || defaultUnderlineColor} />
     </svg>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,13 +64,14 @@ export type Card = 'cb' | 'amex' | 'mastercard' | 'visa'
 
 export type PaymentPlanWidgetOptions = {
   container: string
-  purchaseAmount: number
-  plans?: ConfigPlan[]
-  transitionDelay?: number
-  suggestedPaymentPlan?: number | number[]
   hideIfNotEligible?: boolean
   locale?: Locale
   cards?: Card[]
+  monochrome?: boolean
+  plans?: ConfigPlan[]
+  purchaseAmount: number
+  suggestedPaymentPlan?: number | number[]
+  transitionDelay?: number
 }
 
 export type ModalOptions = {

--- a/src/widgets_controller.tsx
+++ b/src/widgets_controller.tsx
@@ -37,6 +37,7 @@ export class WidgetsController {
         plans,
         transitionDelay,
         hideIfNotEligible,
+        monochrome = true,
         suggestedPaymentPlan,
         locale = Locale.en,
         cards,
@@ -46,13 +47,14 @@ export class WidgetsController {
         render(
           <IntlProvider locale={locale}>
             <PaymentPlanWidget
-              purchaseAmount={purchaseAmount}
               apiData={this.apiData}
               configPlans={plans}
-              transitionDelay={transitionDelay}
               hideIfNotEligible={hideIfNotEligible}
+              monochrome={monochrome}
+              purchaseAmount={purchaseAmount}
               suggestedPaymentPlan={suggestedPaymentPlan}
               cards={cards}
+              transitionDelay={transitionDelay}
             />
           </IntlProvider>,
           document.querySelector(container),


### PR DESCRIPTION
[Clickup issue](https://app.clickup.com/t/20427503/AL-460)

Adding a "monochrome" option the the widgets.

When false, colors from the Alma brand will be used to underline active items.

<img width="454" alt="image" src="https://user-images.githubusercontent.com/25004351/167449236-eeda8e36-2a03-463f-a7c4-858e53b0d882.png">
