### PR TITLE
tsconfig : old exclude parameter deleted, we now have testPathIgnorePatterns in jest.config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "jsx": "react",
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   },
-  "include": ["src", "node_modules/microbundle/index.d.ts"],
-  "exclude": ["**/*.test.tsx"]
+  "include": ["src", "node_modules/microbundle/index.d.ts"]
 }


### PR DESCRIPTION
We still have to tackle the d.ts files from tests files in dist/ folder but this is not the right way.

We should have multiple tsconfig files.
With this parameter, we didn't have those files but we don't have the typescript autocomplete in tests files.
