### PR TITLE
chore(npm-dependency): remove alma client dependency as it is no longer used

### DIFF
--- a/microbundle.config.js
+++ b/microbundle.config.js
@@ -51,11 +51,6 @@ module.exports = {
         }
         return _external(id, ...args)
       }
-      // Make sure @alma/client is exported on the `Alma` global object, and deactivate cache to
-      // ensure the lib is indeed inlined into the bundle
-      // (see https://github.com/rollup/rollup/issues/3874)
-      config.outputOptions.globals['@alma/client'] = 'Alma'
-      config.inputOptions.cache = false
     }
 
     return config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@alma/widgets",
-  "version": "2.3.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alma/widgets",
-      "version": "2.3.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
-        "@alma/client": "^1.1.1",
         "classnames": "^2.3.1",
         "date-fns": "^2.28.0",
         "no-scroll": "^2.1.1",
@@ -68,17 +67,6 @@
         "ts-essentials": "^7.0.1",
         "ts-jest": "^26.4.1",
         "typescript": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@alma/client": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@alma/client/-/client-1.1.2.tgz",
-      "integrity": "sha512-4uuHTnFLaQr6RZEoKCAcSAAmdepFEc819CazZ+6cQxsmMK7vtjfJ2w84Yu7Xs9DjwjeeEmMzkoot7vAQVKegOA==",
-      "dependencies": {
-        "axios": "^0.21.1"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -6565,14 +6553,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "26.6.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
@@ -10300,25 +10280,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -26123,14 +26084,6 @@
     }
   },
   "dependencies": {
-    "@alma/client": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@alma/client/-/client-1.1.2.tgz",
-      "integrity": "sha512-4uuHTnFLaQr6RZEoKCAcSAAmdepFEc819CazZ+6cQxsmMK7vtjfJ2w84Yu7Xs9DjwjeeEmMzkoot7vAQVKegOA==",
-      "requires": {
-        "axios": "^0.21.1"
-      }
-    },
     "@ampproject/remapping": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
@@ -31038,14 +30991,6 @@
         }
       }
     },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "babel-jest": {
       "version": "26.6.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
@@ -33972,11 +33917,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "@alma/client": "^1.1.1",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
     "no-scroll": "^2.1.1",


### PR DESCRIPTION
alma client removed.

This closes https://github.com/alma/widgets/pull/18 