### PR TITLE
AL-870: Add hideBorder props

### DIFF
--- a/dist/types/Widgets/PaymentPlans/index.d.ts
+++ b/dist/types/Widgets/PaymentPlans/index.d.ts
@@ -9,6 +9,7 @@ declare type Props = {
     monochrome: boolean;
     suggestedPaymentPlan?: number | number[];
     cards?: Card[];
+    hideBorder?: boolean;
 };
 declare const PaymentPlanWidget: VoidFunctionComponent<Props>;
 export default PaymentPlanWidget;

--- a/dist/types/types.d.ts
+++ b/dist/types/types.d.ts
@@ -70,6 +70,7 @@ export declare type PaymentPlanWidgetOptions = {
     purchaseAmount: number;
     suggestedPaymentPlan?: number | number[];
     transitionDelay?: number;
+    hideBorder?: boolean;
 };
 export declare type ModalOptions = {
     container: string;

--- a/documentation.md
+++ b/documentation.md
@@ -54,6 +54,10 @@ Totally hides the widget if set to true and no plan matches the purchase amount.
 
 Allow to choose which payment plan's tab will be displayed by default. It will have effect only if the selected plan is eligible. If an array is provided, it will select the first eligible plan from this array.
 
+- hideBorder: `boolean` [optional, default: false]
+
+Hide the border if set to true, set to false as default
+
 ```
 suggestedPaymentPlan: [10, 4],
 ```

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -87,11 +87,11 @@
   <body>
     <div class="body">
       <div>
-        <img src="../src/assets/alma.svg" class="alma-logo" />
+        <img src="../src/assets/alma.svg" class="alma-logo" alt="alma" />
       </div>
       <div class="main">
         <div class="image">
-          <img src="./sac-a-main.jpeg" />
+          <img src="./sac-a-main.jpeg" alt="product" />
         </div>
 
         <div>

--- a/src/Widgets/PaymentPlans/PaymentPlans.module.css
+++ b/src/Widgets/PaymentPlans/PaymentPlans.module.css
@@ -57,6 +57,10 @@
   cursor: not-allowed;
 }
 
+.hideBorder {
+  border: none;
+}
+
 .info {
   font-family: Public Sans, sans-serif;
   font-style: normal;

--- a/src/Widgets/PaymentPlans/__tests__/HideBorder.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/HideBorder.test.tsx
@@ -1,0 +1,33 @@
+import { screen, waitFor } from '@testing-library/react'
+import { ApiMode } from 'consts'
+import React from 'react'
+import render from 'test'
+import PaymentPlanWidget from '..'
+import { mockButtonPlans } from 'test/fixtures'
+
+jest.mock('utils/fetch', () => {
+  return {
+    fetchFromApi: async () => mockButtonPlans,
+  }
+})
+
+it.each([true, false])(
+  'renders the widget without border when expected (hideBorder = %s)',
+  async (hideBorder) => {
+    render(
+      <PaymentPlanWidget
+        purchaseAmount={40000}
+        apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
+        hideBorder={hideBorder}
+        monochrome
+      />,
+    )
+    await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
+    expect(screen.getByTestId('widget-button')).toBeInTheDocument()
+    if (hideBorder) {
+      expect(screen.getByTestId('widget-button').className).toContain('hideBorder')
+    } else {
+      expect(screen.getByTestId('widget-button').className).not.toContain('hideBorder')
+    }
+  },
+)

--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -20,6 +20,7 @@ type Props = {
   monochrome: boolean
   suggestedPaymentPlan?: number | number[]
   cards?: Card[]
+  hideBorder?: boolean
 }
 
 const VERY_LONG_TIME_IN_MS = 1000 * 3600 * 24 * 365
@@ -34,6 +35,7 @@ const PaymentPlanWidget: VoidFunctionComponent<Props> = ({
   suggestedPaymentPlan,
   cards,
   transitionDelay,
+  hideBorder = false
 }) => {
   const [eligibilityPlans, status] = useFetchEligibility(purchaseAmount, apiData, configPlans)
   const eligiblePlans = eligibilityPlans.filter((plan) => plan.eligible)
@@ -121,6 +123,7 @@ const PaymentPlanWidget: VoidFunctionComponent<Props> = ({
           {
             [s.clickable]: eligiblePlans.length > 0,
             [s.unClickable]: eligiblePlans.length === 0,
+            [s.hideBorder]: hideBorder
           },
           STATIC_CUSTOMISATION_CLASSES.container,
         )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,7 @@ export type PaymentPlanWidgetOptions = {
   purchaseAmount: number
   suggestedPaymentPlan?: number | number[]
   transitionDelay?: number
+  hideBorder?: boolean
 }
 
 export type ModalOptions = {

--- a/src/widgets_controller.tsx
+++ b/src/widgets_controller.tsx
@@ -37,6 +37,7 @@ export class WidgetsController {
         plans,
         transitionDelay,
         hideIfNotEligible,
+        hideBorder = false,
         monochrome = true,
         suggestedPaymentPlan,
         locale = Locale.en,
@@ -55,6 +56,7 @@ export class WidgetsController {
               suggestedPaymentPlan={suggestedPaymentPlan}
               cards={cards}
               transitionDelay={transitionDelay}
+              hideBorder={hideBorder}
             />
           </IntlProvider>,
           document.querySelector(container),


### PR DESCRIPTION
### Ticket

https://app.clickup.com/t/20427503/AL-870

### Context

Add the possibility for the merchant to hide the border around the modal

new props: `hideBorder` props

![Capture d’écran du 2022-06-07 14-20-35](https://user-images.githubusercontent.com/104012464/172377484-db2ca215-e331-469a-8e59-73a678abcabe.png)
