### PR TITLE
feat(custom-css): add new static css for bullet

### DIFF
--- a/src/Widgets/EligibilityModal/classNames.const.ts
+++ b/src/Widgets/EligibilityModal/classNames.const.ts
@@ -21,6 +21,7 @@ const STATIC_CUSTOMISATION_CLASSES = {
   scheduleCredit: prefix + '-schedule-credit',
   cardContainer: prefix + '-card-logos',
   summary: prefix + '-summary',
+  bullet: prefix + '-bullet',
 }
 
 export default STATIC_CUSTOMISATION_CLASSES

--- a/src/Widgets/EligibilityModal/components/Info/index.tsx
+++ b/src/Widgets/EligibilityModal/components/Info/index.tsx
@@ -8,7 +8,7 @@ import STATIC_CUSTOMISATION_CLASSES from 'Widgets/EligibilityModal/classNames.co
 const Info: FC = () => (
   <div className={cx(s.list, STATIC_CUSTOMISATION_CLASSES.info)} data-testid="modal-info-element">
     <div className={s.listItem}>
-      <div className={s.bullet}>1</div>
+      <div className={cx(s.bullet, STATIC_CUSTOMISATION_CLASSES.bullet)}>1</div>
       <div className={STATIC_CUSTOMISATION_CLASSES.infoMessage}>
         <FormattedMessage
           id="eligibility-modal.bullet-1"


### PR DESCRIPTION
This is a test branch with a feature we might want anyway : a new static css class for bullet.

This branch is created beta on purpose it's to test if semantic release will append to the version the desired `-beta.1`