### PR TITLE
Fix/mobile click plan

### DIFF
--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -135,7 +135,9 @@ const PaymentPlanWidget: VoidFunctionComponent<Props> = ({
                 <div
                   key={key}
                   onMouseEnter={() => onHover(key)}
+                  onTouchStart={() => onHover(key)}
                   onMouseOut={onLeave}
+                  onTouchEnd={onLeave}
                   className={cx(s.plan, {
                     [cx(s.active, STATIC_CUSTOMISATION_CLASSES.activeOption)]: isCurrent,
                     [s.polychrome]: !monochrome && isCurrent,

--- a/src/hooks/useButtonAnimation.ts
+++ b/src/hooks/useButtonAnimation.ts
@@ -1,17 +1,20 @@
 import { useEffect, useState } from 'react'
 
-const useButtonAnimation = (
-  iterateValues: number[],
-  transitionDelay: number,
-): { current: number; onHover: (current: number) => void; onLeave: () => void } => {
+type Props = {
+  current: number
+  onHover: (current: number) => void
+  onLeave: () => void
+}
+const useButtonAnimation = (iterateValues: number[], transitionDelay: number): Props => {
   const [current, setCurrent] = useState(0)
   const [update, setUpdate] = useState(true)
 
   useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>
     let isMounted = true
     if (iterateValues.length !== 0) {
       if (!iterateValues.includes(current) && update) setCurrent(iterateValues[0])
-      setTimeout(() => {
+      timeout = setTimeout(() => {
         if (update && isMounted) {
           setCurrent(
             iterateValues[
@@ -25,8 +28,10 @@ const useButtonAnimation = (
     }
     return () => {
       isMounted = false
+      clearTimeout(timeout)
     }
   }, [iterateValues, current])
+
   return {
     current,
     onHover: (current: number) => {


### PR DESCRIPTION
Widget modification on eligibility plan.

On mobile, when a user clicks on a plan, it displays the modale but not with the clicked plan (albeit the first click)

Also the useEffect on useButtonAnimation was not cleaned properly for the timeout. We did not have any issue with this so far, but it was going to happen one day.


# How to test

Start the project like usual, use your mobile and click on a plan to see the modale displayed with the right plan.
Use a cdn to try an old version and check it was not working (optional :p)