### PR TITLE
Add monochrome property to tests

### DIFF
--- a/src/Widgets/PaymentPlans/__tests__/Basics.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/Basics.test.tsx
@@ -14,6 +14,7 @@ jest.mock('utils/fetch', () => {
 beforeEach(async () => {
   render(
     <PaymentPlanWidget
+      monochrome={false}
       purchaseAmount={40000}
       apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
     />,

--- a/src/Widgets/PaymentPlans/__tests__/Credit.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/Credit.test.tsx
@@ -18,6 +18,7 @@ describe('PaymentPlan has credit', () => {
   beforeEach(async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={40000}
         apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
         configPlans={[

--- a/src/Widgets/PaymentPlans/__tests__/CustomTransitionDelay.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/CustomTransitionDelay.test.tsx
@@ -18,6 +18,7 @@ describe('Custom transition delay', () => {
   beforeEach(async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={40000}
         apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
         transitionDelay={animationDuration}

--- a/src/Widgets/PaymentPlans/__tests__/HideWidget.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/HideWidget.test.tsx
@@ -15,6 +15,7 @@ describe('Hide if not applicable', () => {
   it('hides if hideIfNotEligible is true', async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={40000}
         apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
         hideIfNotEligible={true}
@@ -32,6 +33,7 @@ describe('Hide if not applicable', () => {
   it('hides if hideIfNotEligible is not specified', async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={40000}
         apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
         configPlans={[
@@ -48,6 +50,7 @@ describe('Hide if not applicable', () => {
   it('hides if there is no plan', async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={40000}
         apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
         configPlans={[]}

--- a/src/Widgets/PaymentPlans/__tests__/IneligibleOptions.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/IneligibleOptions.test.tsx
@@ -18,6 +18,7 @@ describe('PaymentPlan has ineligible options from configPlans', () => {
   beforeEach(async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={45000}
         configPlans={[
           {
@@ -76,6 +77,7 @@ describe('PaymentPlan has ineligible options from merchant config', () => {
   beforeEach(async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={45000}
         configPlans={[
           {

--- a/src/Widgets/PaymentPlans/__tests__/LaunchModal.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/LaunchModal.test.tsx
@@ -15,6 +15,7 @@ describe('Modal initializes with the correct plan', () => {
   it('after hovering a plan', async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={40000}
         apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
       />,
@@ -35,6 +36,7 @@ describe('Modal initializes with the correct plan', () => {
   it('after clicking a plan (fallback for mobile)', async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={40000}
         apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
       />,
@@ -54,6 +56,7 @@ describe('Modal initializes with the correct plan', () => {
   it('after a simple click on the badge, with no hover or click on a specific plan', async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={40000}
         apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
       />,

--- a/src/Widgets/PaymentPlans/__tests__/SuggestedPaymentPlan.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/SuggestedPaymentPlan.test.tsx
@@ -20,6 +20,7 @@ describe('PaymentPlan has suggestedPaymentPlan', () => {
     beforeEach(async () => {
       render(
         <PaymentPlanWidget
+          monochrome={false}
           purchaseAmount={40000}
           apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
           suggestedPaymentPlan={2}
@@ -38,6 +39,7 @@ describe('PaymentPlan has suggestedPaymentPlan', () => {
     beforeEach(async () => {
       render(
         <PaymentPlanWidget
+          monochrome={false}
           purchaseAmount={40000}
           apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
           suggestedPaymentPlan={[3, 2]}
@@ -63,6 +65,7 @@ describe('PaymentPlan has suggestedPaymentPlan', () => {
     beforeEach(async () => {
       render(
         <PaymentPlanWidget
+          monochrome={false}
           purchaseAmount={40000}
           configPlans={[
             {
@@ -109,6 +112,7 @@ describe('PaymentPlan has suggestedPaymentPlan', () => {
     beforeEach(async () => {
       render(
         <PaymentPlanWidget
+          monochrome={false}
           purchaseAmount={40000}
           apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
           suggestedPaymentPlan={[20]}
@@ -128,6 +132,7 @@ describe('PaymentPlan has suggestedPaymentPlan', () => {
     beforeEach(async () => {
       render(
         <PaymentPlanWidget
+          monochrome={false}
           purchaseAmount={40000}
           transitionDelay={1000}
           apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}

--- a/src/Widgets/PaymentPlans/__tests__/WithoutPlans.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/WithoutPlans.test.tsx
@@ -19,6 +19,7 @@ describe('No plans provided', () => {
   beforeEach(async () => {
     render(
       <PaymentPlanWidget
+        monochrome={false}
         purchaseAmount={mockButtonPlans[0].purchase_amount}
         apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
       />,


### PR DESCRIPTION
This PR is here only because the previous one was labelled as "chore" and didn't trigger a new version deployment. 

The changes are the addition `monochrome` property to tests that are missing it.

I hope this will trigger a new version when merged.