### PR TITLE
Fix deferred translations

### DIFF
--- a/src/Widgets/PaymentPlans/__tests__/LanguageCheck.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/LanguageCheck.test.tsx
@@ -26,7 +26,7 @@ describe('Change language', () => {
     )
     await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
 
-    expect(screen.getByText('T+30')).toBeInTheDocument()
+    expect(screen.getByText('D+30')).toBeInTheDocument()
     expect(screen.getByText(/to be paid on/)).toBeInTheDocument()
     expect(screen.getByText(/\(free of charge\)/)).toBeInTheDocument()
   })

--- a/src/intl/messages/messages.en.json
+++ b/src/intl/messages/messages.en.json
@@ -11,7 +11,7 @@
   "eligibility-modal.title-deferred": "<highlighted>Pay in installments</highlighted> or later by credit card with Alma.",
   "eligibility-modal.total": "Total",
   "installments.today": "Today",
-  "payment-plan-strings.day-abbreviation": "T{numberOfDeferredDays}",
+  "payment-plan-strings.day-abbreviation": "D{numberOfDeferredDays}",
   "payment-plan-strings.default-message": "Pay in installments with Alma",
   "payment-plan-strings.deferred": "{totalAmount} to be paid on {dueDate}",
   "payment-plan-strings.ineligible-greater-than-max": "Until {maxAmount}",

--- a/src/intl/messages/messages.es.json
+++ b/src/intl/messages/messages.es.json
@@ -1,7 +1,7 @@
 {
   "eligibility-modal.bullet-1": "Elige <strong>Alma</strong> como método de pago.",
   "eligibility-modal.bullet-2": "Completa la <strong>información</strong> solicitada.",
-  "eligibility-modal.bullet-3": "¡La validación de su pago es <strong>instantánea</strong> !",
+  "eligibility-modal.bullet-3": "¡La validación de tu pago es <strong>instantánea</strong> !",
   "eligibility-modal.cost": "Gastos (incl. en el total)",
   "eligibility-modal.credit-commitment": "Un préstamo te compromete y debe ser devuelto. Comprueba tu capacidad financiera antes de comprometerte.",
   "eligibility-modal.credit-cost": "Coste de crédito (incl. en el total)",


### PR DESCRIPTION
Translation for deferred days in english should be D+30 instead of T+30

[Clickup ticket](https://app.clickup.com/t/20427503/SPT-1774)

![Capture d’écran 2022-08-02 à 15 42 25](https://user-images.githubusercontent.com/92718741/182390299-a8ebd958-293d-4c2b-a180-9343dbb60bc8.png)
