### PR TITLE
fix: move the css reset where it matters, in the modal only

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -16,6 +16,8 @@
 
 .contentScrollable {
   overflow-y: auto;
+  margin: 0;
+  box-sizing: border-box;
 }
 
 .overlay {
@@ -35,8 +37,8 @@
   display: flex;
   justify-content: flex-end;
   position: absolute;
-  top: 24px;
-  right: 24px;
+  top: 15px;
+  right: 15px;
   z-index: 1;
 }
 

--- a/src/main.css
+++ b/src/main.css
@@ -1,11 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Public+Sans:wght@300;600&family=Work+Sans:wght@700&display=swap');
 
-* {
-  padding: 0;
-  margin: 0;
-  box-sizing: border-box;
-}
-
 :root {
   --white: #fff;
   --blue-100: #e9f4ff;


### PR DESCRIPTION
A merchant complained about some Reset Rule that we ship on the widget.

I removed the reset CSS that was indeed shipped to all our merchants.
I moved the important part on the modal, where it seems to have an impact.

I tested and see no regression, however, i'm a little bit scared of the impact it might have on merchant's website. Can someone else take a look at it and tell me if we need to create a breaking change for this ? 