### PR TITLE
fix: update locale to adapt to more options

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -44,7 +44,7 @@ An array of the plans you want to display. If not provided, the widget returns a
 
 The amount of time in between button animations in ms.
 
-- locale: `fr|en|es|it|de|nl|pt` [optional, default: en]
+- locale: `fr|es|it|de|nl|pt|en` or local-country format (e.g `fr-FR|de-DE|it-IT`) [optional, default: en]
 
 - hideIfNotEligible: `boolean` [optional, default: false]
 

--- a/src/Widgets/PaymentPlans/__tests__/LanguageCheck.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/LanguageCheck.test.tsx
@@ -85,6 +85,24 @@ describe('Change language', () => {
     expect(screen.getByText(/\(senza interessi\)/)).toBeInTheDocument()
   })
 
+  it(`into ${Locale['it-IT']}`, async () => {
+    render(
+      <PaymentPlanWidget
+        monochrome={false}
+        purchaseAmount={40000}
+        apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
+      />,
+      {
+        locale: Locale['it-IT'],
+      },
+    )
+    await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
+
+    expect(screen.getByText('G+30')).toBeInTheDocument()
+    expect(screen.getByText(/da pagare il/)).toBeInTheDocument()
+    expect(screen.getByText(/\(senza interessi\)/)).toBeInTheDocument()
+  })
+
   it(`into ${Locale.nl}`, async () => {
     render(
       <PaymentPlanWidget

--- a/src/components/Installments/TotalBlock/index.tsx
+++ b/src/components/Installments/TotalBlock/index.tsx
@@ -19,10 +19,10 @@ const TotalBlock: FunctionComponent<{ currentPlan: EligibilityPlan }> = ({ curre
       className={cx(s.container, STATIC_CUSTOMISATION_CLASSES.summary)}
       data-testid="modal-summary"
     >
-      <h3 className={cx(s.total, STATIC_CUSTOMISATION_CLASSES.scheduleTotal)}>
+      <div className={cx(s.total, STATIC_CUSTOMISATION_CLASSES.scheduleTotal)}>
         <FormattedMessage tagName="div" id="installments.total-amount" defaultMessage="Total" />
         <FormattedNumber value={total || 0} style="currency" currency="EUR" />
-      </h3>
+      </div>
       <div className={cx(s.fees, STATIC_CUSTOMISATION_CLASSES.scheduleCredit)}>
         {isCredit ? (
           <>

--- a/src/intl/utils.ts
+++ b/src/intl/utils.ts
@@ -8,7 +8,10 @@ import messagesPT from 'intl/messages/messages.pt.json'
 import { Locale } from 'types'
 
 export const getTranslationsByLocale = (locale: Locale): Record<string, string> => {
-  switch (locale) {
+  // A CMS plugin can add LCID format like : 'fr-FR' instead of 'fr'.
+  // Instead of specifying all possibilities we just remove the last part of the string.
+  const merchantLocale = locale.slice(0, 2)
+  switch (merchantLocale) {
     case Locale.fr:
       return messagesFR
     case Locale.es:
@@ -20,8 +23,6 @@ export const getTranslationsByLocale = (locale: Locale): Record<string, string> 
     case Locale.pt:
       return messagesPT
     case Locale.nl:
-    case Locale['nl-BE']:
-    case Locale['nl-NL']:
       return messagesNL
     case Locale.en:
     default:

--- a/src/main.css
+++ b/src/main.css
@@ -18,7 +18,6 @@
   --soft-green: #e2f3e1;
   --alma-red: #f00;
   --soft-red: #ffecec;
-  --background: #fefefe;
   --off-white: #f9f9f9;
   --light-gray: #d4d4d4;
   --dark-gray: #8c8c8c;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,12 +51,17 @@ export type EligibilityPlanToDisplay = EligibilityPlan & {
 
 export enum Locale {
   en = 'en',
+  'fr-FR' = 'fr-FR',
   fr = 'fr',
+  'de-DE' = 'de-DE',
   de = 'de',
   it = 'it',
+  'it-IT' = 'it-IT',
   es = 'es',
-  nl = 'nl',
+  'es-ES' = 'es-ES',
   pt = 'pt',
+  'pt-PT' = 'pt-PT',
+  nl = 'nl',
   'nl-NL' = 'nl-NL',
   'nl-BE' = 'nl-BE',
 }


### PR DESCRIPTION
Some CMS use a LCID format for the locale, which makes the widget go into the default case : en (but not for the formattedDates).

To avoid specifying locale 1 by 1 I used the first two letters to specify the language it should be in. 

I also changed the h3 into a div to avoid some CSS override with specific CMS
I also removed a background css variable that was not used (used to)