### PR TITLE
add shipping/billing country to eligibility to fetch the proper feeplans

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -10,8 +10,8 @@ Your merchant id as it is found in the dashboard
 
 ### domain `Alma.ApiMode.TEST | Alma.ApiMode.LIVE` [required]
 
-- `Alma.ApiMode.TEST` Used to test the widget
-- `Alma.ApiMode.LIVE` Used in production mode. data will match what is provided in your dashboard
+- `Alma.ApiMode.TEST` Used to test the widget. Data will match what is provided in your sandbox dashboard
+- `Alma.ApiMode.LIVE` Used in production mode. Data will match what is provided in your production dashboard
 
 ## Add PaymentPlans
 
@@ -57,6 +57,12 @@ If set to `false`, Alma's logo and the active payments plan will be underlined i
 - suggestedPaymentPlan: `number` | `number[]` [optional]
 
 Allow to choose which payment plan's tab will be displayed by default. It will have effect only if the selected plan is eligible. If an array is provided, it will select the first eligible plan from this array.
+
+- customerBillingCountry: `string` (e.g `fr|es|it|de|nl|pt|en`) [optional]
+- customerShippingCountry: `string` (e.g `fr|es|it|de|nl|pt|en`) [optional]
+
+Allow to display fee plans specific for a country. Example: you're selling in France and Germany, the credit options are only available in France, so you can specify this option to 'fr' to show credits on the widget for french customers.
+Both options offer the same result, they allow to simplify the integration if there is no information about customer's shipping address.
 
 ```
 suggestedPaymentPlan: [10, 4],
@@ -110,6 +116,12 @@ If provided, the modal will open when the element matching this query selector i
 - cards: `cb|visa|amex|mastercard`[] [optional]
 
 Display card logos in the modal
+
+- customerBillingCountry: `string` (e.g `fr|es|it|de|nl|pt|en`) [optional]
+- customerShippingCountry: `string` (e.g `fr|es|it|de|nl|pt|en`) [optional]
+
+Allow to display fee plans specific for a country. Example: you're selling in France and Germany, the credit options are only available in France, so you can specify this option to 'fr' to show credits on the widget for french customers.
+Both options offer the same result, they allow to simplify the integration if there is no information about customer's shipping address.
 
 ## Plan option: `Plan`
 

--- a/src/Widgets/EligibilityModal/ModalContainer.tsx
+++ b/src/Widgets/EligibilityModal/ModalContainer.tsx
@@ -7,6 +7,8 @@ type Props = {
   purchaseAmount: number
   apiData: ApiConfig
   configPlans?: ConfigPlan[]
+  customerBillingCountry?: string
+  customerShippingCountry?: string
   onClose: () => void
   cards?: Card[]
 }
@@ -14,8 +16,22 @@ type Props = {
 /**
  * This component allows to display only the modal, without PaymentPlans.
  */
-const ModalContainer: React.FC<Props> = ({ purchaseAmount, apiData, configPlans, onClose, cards }) => {
-  const [eligibilityPlans, status] = useFetchEligibility(purchaseAmount, apiData, configPlans)
+const ModalContainer: React.FC<Props> = ({
+  purchaseAmount,
+  apiData,
+  configPlans,
+  customerBillingCountry,
+  customerShippingCountry,
+  onClose,
+  cards,
+}) => {
+  const [eligibilityPlans, status] = useFetchEligibility(
+    purchaseAmount,
+    apiData,
+    configPlans,
+    customerBillingCountry,
+    customerShippingCountry,
+  )
 
   return (
     <EligibilityModal

--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -16,6 +16,8 @@ type Props = {
   apiData: ApiConfig
   configPlans?: ConfigPlan[]
   transitionDelay?: number
+  customerBillingCountry?: string
+  customerShippingCountry?: string
   hideIfNotEligible?: boolean
   monochrome?: boolean
   suggestedPaymentPlan?: number | number[]
@@ -34,10 +36,18 @@ const PaymentPlanWidget: VoidFunctionComponent<Props> = ({
   purchaseAmount,
   suggestedPaymentPlan,
   cards,
+  customerBillingCountry,
+  customerShippingCountry,
   transitionDelay,
   hideBorder = false,
 }) => {
-  const [eligibilityPlans, status] = useFetchEligibility(purchaseAmount, apiData, configPlans)
+  const [eligibilityPlans, status] = useFetchEligibility(
+    purchaseAmount,
+    apiData,
+    configPlans,
+    customerBillingCountry,
+    customerShippingCountry,
+  )
   const eligiblePlans = eligibilityPlans.filter((plan) => plan.eligible)
   const activePlanIndex = getIndexOfActivePlan({
     eligibilityPlans,

--- a/src/hooks/useFetchEligibility.ts
+++ b/src/hooks/useFetchEligibility.ts
@@ -7,6 +7,8 @@ const useFetchEligibility = (
   purchaseAmount: number,
   { domain, merchantId }: ApiConfig,
   plans?: ConfigPlan[],
+  customerBillingCountry?: string,
+  customerShippingCountry?: string,
 ): [EligibilityPlan[], apiStatus] => {
   const [eligibility, setEligibility] = useState([] as EligibilityPlan[])
   const [status, setStatus] = useState(apiStatus.PENDING)
@@ -17,11 +19,26 @@ const useFetchEligibility = (
   }))
   useEffect(() => {
     if (status === apiStatus.PENDING) {
+      let billing_address = null
+      if (customerBillingCountry) {
+        billing_address = {
+          country: customerBillingCountry,
+        }
+      }
+
+      let shipping_address = null
+      if (customerShippingCountry) {
+        shipping_address = {
+          country: customerShippingCountry,
+        }
+      }
       fetchFromApi(
         domain + '/v2/payments/eligibility',
         {
           purchase_amount: purchaseAmount,
           queries: configInstallments,
+          billing_address,
+          shipping_address,
         },
         {
           Authorization: `Alma-Merchant-Auth ${merchantId}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,12 +79,16 @@ export type PaymentPlanWidgetOptions = {
   suggestedPaymentPlan?: number | number[]
   transitionDelay?: number
   hideBorder?: boolean
+  customerBillingCountry?: string
+  customerShippingCountry?: string
 }
 
 export type ModalOptions = {
   container: string
   clickableSelector: string
   purchaseAmount: number
+  customerBillingCountry?: string
+  customerShippingCountry?: string
   plans?: ConfigPlan[]
   locale?: Locale
   cards?: Card[]

--- a/src/widgets_controller.tsx
+++ b/src/widgets_controller.tsx
@@ -40,6 +40,8 @@ export class WidgetsController {
         hideBorder = false,
         monochrome = true,
         suggestedPaymentPlan,
+        customerBillingCountry,
+        customerShippingCountry,
         locale = Locale.en,
         cards,
       } = options as PaymentPlanWidgetOptions
@@ -55,6 +57,8 @@ export class WidgetsController {
               purchaseAmount={purchaseAmount}
               suggestedPaymentPlan={suggestedPaymentPlan}
               cards={cards}
+              customerBillingCountry={customerBillingCountry}
+              customerShippingCountry={customerShippingCountry}
               transitionDelay={transitionDelay}
               hideBorder={hideBorder}
             />
@@ -71,6 +75,8 @@ export class WidgetsController {
         purchaseAmount,
         plans,
         locale = Locale.en,
+        customerBillingCountry,
+        customerShippingCountry,
         cards,
       } = options as ModalOptions
 
@@ -83,6 +89,8 @@ export class WidgetsController {
               purchaseAmount={purchaseAmount}
               apiData={this.apiData}
               configPlans={plans}
+              customerBillingCountry={customerBillingCountry}
+              customerShippingCountry={customerShippingCountry}
               onClose={close}
               cards={cards}
             />


### PR DESCRIPTION
# Why 
Some merchants are located in a country other than France and want to show credit options for french customer.
The Eligibility API allows this by specifying the billindAdress->country option (or shippingAddress) but we have no way of knowing this customer information most of the time as the customer might not even be connected.

So there is a 2 new options on the widget for this (so that the integration team can update this easily)

# How to test
Ping me, as I need to give you a merchant ID to test a real case.