### PR TITLE
Special wording on widgets for pay now

### DIFF
--- a/src/Widgets/PaymentPlans/__tests__/CustomTransitionDelay.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/CustomTransitionDelay.test.tsx
@@ -32,7 +32,7 @@ describe('Custom transition delay', () => {
     act(() => {
       jest.advanceTimersByTime(animationDuration)
     })
-    expect(screen.getByText(/1 x 450,00 €/)).toBeInTheDocument()
+    expect(screen.getByText(/Payez maintenant 450,00 €/)).toBeInTheDocument()
     expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
     act(() => {
       jest.advanceTimersByTime(animationDuration)

--- a/src/Widgets/PaymentPlans/__tests__/SuggestedPaymentPlan.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/SuggestedPaymentPlan.test.tsx
@@ -35,7 +35,7 @@ describe('PaymentPlan has suggestedPaymentPlan', () => {
     it('should target the P1X and not a PayLater plan when suggested plan is 1', async () => {
       renderPlans(1)
       await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
-      expect(screen.getByText(/1 x 450,00 €/)).toBeInTheDocument()
+      expect(screen.getByText(/Payez maintenant 450,00 €/)).toBeInTheDocument()
       expect(screen.getByText('1x').className).toContain('active')
     })
   })

--- a/src/Widgets/PaymentPlans/__tests__/WithoutPlans.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/WithoutPlans.test.tsx
@@ -41,7 +41,7 @@ describe('No plans provided', () => {
     act(() => {
       jest.advanceTimersByTime(animationDuration)
     })
-    expect(screen.getByText(/1 x 450,00 €/)).toBeInTheDocument()
+    expect(screen.getByText(/Payez maintenant 450,00 €/)).toBeInTheDocument()
     expect(screen.getByText(/\(sans frais\)/)).toBeInTheDocument()
   })
 })

--- a/src/intl/messages.json
+++ b/src/intl/messages.json
@@ -21,5 +21,6 @@
   "payment-plan-strings.ineligible-lower-than-min": "À partir de {minAmount}",
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
-  "payment-plan-strings.no-fee": "(sans frais)"
+  "payment-plan-strings.no-fee": "(sans frais)",
+  "payment-plan-strings.pay-now": "Payez maintenant {totalAmount}"
 }

--- a/src/intl/messages/messages.de.json
+++ b/src/intl/messages/messages.de.json
@@ -21,5 +21,6 @@
   "payment-plan-strings.ineligible-lower-than-min": "Ab {minAmount}",
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} dann {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} dann {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
-  "payment-plan-strings.no-fee": "(0% Finanzierung)"
+  "payment-plan-strings.no-fee": "(0% Finanzierung)",
+  "payment-plan-strings.pay-now": "Bezahlen Sie jetzt {totalAmount}"
 }

--- a/src/intl/messages/messages.en.json
+++ b/src/intl/messages/messages.en.json
@@ -21,5 +21,6 @@
   "payment-plan-strings.ineligible-lower-than-min": "From {minAmount}",
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} then {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} then {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
-  "payment-plan-strings.no-fee": "(free of charge)"
+  "payment-plan-strings.no-fee": "(free of charge)",
+  "payment-plan-strings.pay-now": "Pay now {totalAmount}"
 }

--- a/src/intl/messages/messages.es.json
+++ b/src/intl/messages/messages.es.json
@@ -21,5 +21,6 @@
   "payment-plan-strings.ineligible-lower-than-min": "Desde {minAmount}",
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} hoy, después {numberOfRemainingInstallments} mensualidad de {othersInstallmentAmount}} other {{firstInstallmentAmount} hoy, después {numberOfRemainingInstallments} mensualidades de {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} plazos de {totalAmount}",
-  "payment-plan-strings.no-fee": "(sin intereses)"
+  "payment-plan-strings.no-fee": "(sin intereses)",
+  "payment-plan-strings.pay-now": "Pague ahora {totalAmount}"
 }

--- a/src/intl/messages/messages.fr.json
+++ b/src/intl/messages/messages.fr.json
@@ -21,5 +21,6 @@
   "payment-plan-strings.ineligible-lower-than-min": "À partir de {minAmount}",
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
-  "payment-plan-strings.no-fee": "(sans frais)"
+  "payment-plan-strings.no-fee": "(sans frais)",
+  "payment-plan-strings.pay-now": "Payez maintenant {totalAmount}"
 }

--- a/src/intl/messages/messages.it.json
+++ b/src/intl/messages/messages.it.json
@@ -21,5 +21,6 @@
   "payment-plan-strings.ineligible-lower-than-min": "Pagamento rateale disponibile a partire da {minAmount}",
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {Oggi paghi {firstInstallmentAmount} poi tra {numberOfRemainingInstallments} mese {othersInstallmentAmount}} other {Oggi paghi {firstInstallmentAmount} poi {numberOfRemainingInstallments} rate mensili di {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "In {installmentsCount} rate mensili di {totalAmount}",
-  "payment-plan-strings.no-fee": "(senza interessi)"
+  "payment-plan-strings.no-fee": "(senza interessi)",
+  "payment-plan-strings.pay-now": "Paga ora {totalAmount}"
 }

--- a/src/intl/messages/messages.nl.json
+++ b/src/intl/messages/messages.nl.json
@@ -21,5 +21,6 @@
   "payment-plan-strings.ineligible-lower-than-min": "Van {minAmount}",
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} dan {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} dan {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
-  "payment-plan-strings.no-fee": "(zonder kosten)"
+  "payment-plan-strings.no-fee": "(zonder kosten)",
+  "payment-plan-strings.pay-now": "Betaal nu {totalAmount}"
 }

--- a/src/intl/messages/messages.pt.json
+++ b/src/intl/messages/messages.pt.json
@@ -21,5 +21,6 @@
   "payment-plan-strings.ineligible-lower-than-min": "A partir de {minAmount}",
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} depois {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} depois {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
-  "payment-plan-strings.no-fee": "(sem encargos)"
+  "payment-plan-strings.no-fee": "(sem encargos)",
+  "payment-plan-strings.pay-now": "Pague agora {totalAmount}"
 }

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -2,7 +2,7 @@ import { secondsToMilliseconds } from 'date-fns'
 import React, { ReactNode } from 'react'
 import { FormattedDate, FormattedMessage, FormattedNumber } from 'react-intl'
 import { EligibilityPlan, EligibilityPlanToDisplay } from 'types'
-import { priceFromCents } from 'utils'
+import { isP1X, priceFromCents } from 'utils'
 
 export const paymentPlanShorthandName = (payment: EligibilityPlan): ReactNode => {
   const { deferred_days, deferred_months, installments_count: installmentsCount } = payment
@@ -111,6 +111,28 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
       (installment, index) =>
         index === 0 || installment.total_amount === payment_plan[0].total_amount,
     )
+
+    if (isP1X(payment)) {
+      return (
+        <>
+          <FormattedMessage
+            id="payment-plan-strings.pay-now"
+            defaultMessage="Payez maintenant {totalAmount}"
+            values={{
+              totalAmount: (
+                <FormattedNumber
+                  value={priceFromCents(payment_plan[0].total_amount)}
+                  style="currency"
+                  currency="EUR"
+                />
+              ),
+              installmentsCount,
+            }}
+          />
+          {withNoFee(payment)}
+        </>
+      )
+    }
 
     if (areInstallmentsOfSameAmount) {
       return (


### PR DESCRIPTION
A special wording on hover of the p1x plan was forgotten in last PRs :

Before
<img width="383" alt="Capture d’écran 2023-02-21 à 12 10 03" src="https://user-images.githubusercontent.com/33830009/220332061-0ab77fb5-c722-45b7-a283-0ddce895b424.png">

After
<img width="457" alt="Capture d’écran 2023-02-21 à 12 23 55" src="https://user-images.githubusercontent.com/33830009/220332201-590e0a75-b317-4f20-9906-a691cfbb2405.png">


Mockup for reference
<img width="540" alt="Capture d’écran 2023-02-21 à 12 09 25" src="https://user-images.githubusercontent.com/33830009/220332096-3f5ad1b1-b458-49c6-bb17-b9d833c081cc.png">
