### PR TITLE
CI: add workflow to purge jsdelivr cache

### DIFF
--- a/.github/workflows/purge-js-delivr-cache.yml
+++ b/.github/workflows/purge-js-delivr-cache.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           url: https://purge.jsdelivr.net/
           method: "POST"
+          accept: 200,201,204,202
           headers: '{ "cache-control": "no-cache", "content-type": "application/json" }'
           body: "{'path': ['/npm/@alma/widgets@3.x.x/dist/widgets.umd.js','/npm/@alma/widgets@3.x/dist/widgets.umd.js','/npm/@alma/widgets@3.x.x/dist/widgets.module.css','/npm/@alma/widgets@3.x/dist/widgets.module.css','/npm/@alma/widgets@3.x.x/dist/widgets.css','/npm/@alma/widgets@3.x/dist/widgets.css','/npm/@alma/widgets@3.x.x/dist/widgets.min.css','/npm/@alma/widgets@3.x/dist/widgets.min.css']}"
 

--- a/.github/workflows/purge-js-delivr-cache.yml
+++ b/.github/workflows/purge-js-delivr-cache.yml
@@ -1,5 +1,10 @@
+# Temporary trigger workflow on PR to test the job
+#on:
+#  workflow_dispatch:
+
 on:
-  workflow_dispatch:
+  pull_request:
+    branches: [master]
 
 jobs:
   test-curl-action:

--- a/.github/workflows/purge-js-delivr-cache.yml
+++ b/.github/workflows/purge-js-delivr-cache.yml
@@ -1,0 +1,19 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  test-curl-action:
+    name: "Curl to purge JSDelivr cache"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Curl"
+        uses: indiesdev/curl@v1.1
+        with:
+          url: https://purge.jsdelivr.net/
+          method: "POST"
+          headers: '{ "cache-control": "no-cache", "content-type": "application/json" }'
+          body: "{'path': ['/npm/@alma/widgets@3.x.x/dist/widgets.umd.js','/npm/@alma/widgets@3.x/dist/widgets.umd.js','/npm/@alma/widgets@3.x.x/dist/widgets.module.css','/npm/@alma/widgets@3.x/dist/widgets.module.css','/npm/@alma/widgets@3.x.x/dist/widgets.css','/npm/@alma/widgets@3.x/dist/widgets.css','/npm/@alma/widgets@3.x.x/dist/widgets.min.css','/npm/@alma/widgets@3.x/dist/widgets.min.css']}"
+
+          # If it is set to true, it will show the response log in the GitHub UI
+          log-response: true
+

--- a/.github/workflows/purge-js-delivr-cache.yml
+++ b/.github/workflows/purge-js-delivr-cache.yml
@@ -1,13 +1,8 @@
-# Temporary trigger workflow on PR to test the job
-#on:
-#  workflow_dispatch:
-
 on:
-  pull_request:
-    branches: [master]
+  workflow_dispatch:
 
 jobs:
-  test-curl-action:
+  purge-jsdelivr-cache:
     name: "Curl to purge JSDelivr cache"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a workflow to manually purge JSDelivr cache when needed