### PR TITLE
feat: add onClose to Modal options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,7 @@ export type ModalOptions = {
   plans?: ConfigPlan[]
   locale?: Locale
   cards?: Card[]
+  onClose: () => void
 }
 
 export type WidgetNames = keyof typeof widgetTypes

--- a/src/widgets_controller.tsx
+++ b/src/widgets_controller.tsx
@@ -78,9 +78,14 @@ export class WidgetsController {
         customerBillingCountry,
         customerShippingCountry,
         cards,
+        onClose,
       } = options as ModalOptions
 
-      const close = () => containerDiv && unmountComponentAtNode(containerDiv)
+      const close = () => {
+        if (!containerDiv) return
+        unmountComponentAtNode(containerDiv)
+        onClose()
+      }
 
       const renderModal = () => {
         render(


### PR DESCRIPTION
Could you please consider to add onClose to the Modal options to allow to perform some actions ?
Currently the modal is automatically closed on blur but there is no way to catch the event.