### PR TITLE
Reset display property for button to avoid override

### DIFF
--- a/src/Widgets/EligibilityModal/components/EligibilityPlansButtons/EligibilityPlansButtons.module.css
+++ b/src/Widgets/EligibilityModal/components/EligibilityPlansButtons/EligibilityPlansButtons.module.css
@@ -10,6 +10,7 @@
 }
 
 .buttons > button {
+  display: initial;
   height: 50px;
   min-width: 50px;
   border: 1px solid var(--dark-gray);


### PR DESCRIPTION
Some merchant add style to their website, and if it override our style, it can break the widget's design.
For now, we noticed that `display` was a common property that is overriden in button's style, so this PR fixes it.
