### PR TITLE
Add on close for modal

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -28,56 +28,22 @@ Add a button with the eligibles payment plans for the given purchase amount
 
 ### `PaymentPlansOptions`
 
-- container: `string` [required]
+| Option name             |                                                                      Type                                                                       |               Required               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+|:------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| container               |                                                                    `string`                                                                     |             **required**             | Your container's selector                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| purchaseAmount          |                                                                    `number`                                                                     |             **required**             | The purchase amount (in euro cents)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| plans                   |                                                 `Plan[]`   [more info below](#plan-option-plan)                                                 |               optional               | An array of the plans you want to display. If not provided, the widget returns all your available payment plans.                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| transitionDelay         |                                                                    `number`                                                                     |  optional (default value is `5500`)  | The amount of time in between button animations in ms.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+ | locale                  | `fr` or `es` or  `it` or `de` or `nl` or `pt`, or `en` or local-country format (e.g `fr-FR`, `de-DE`, `it-IT`)[more info below](#locale-option) | optional (default value is  `"en"`)  | Defines the language displayed on the widgets                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+ | hideIfNotEligible       |                                                                    `boolean`                                                                    | optional (default value is `false`)  | Totally hides the widget if set to true and no plan matches the purchase amount.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+ | monochrome              |                                                                    `boolean`                                                                    |  optional (default value is `true`)  | If set to `false`, Alma's logo and the active payments plan will be orange (#FA5022).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+ | suggestedPaymentPlan    |                                         `number`                                     or      `number[]`                                         |               optional               | Allow to choose which payment plan's tab will be displayed by default. It will have effect only if the selected plan is eligible. If an array is provided, it will select the first eligible plan from this array.<br /> ex: `suggestedPaymentPlan: [10, 4]` In this example, the 10 installments plan will be selected. If it's not eligible, the 4 installments plan will be selected. If the 4 installments plan is not eligible, it will select the first tab. When `suggestedPaymentPlan` is used, the transition is disable. Unless `transitionDelay` is specified. |
+ | customerBillingCountry  |                    `string` (e.g `fr` or `es` or  `it` or `de` or `nl` or `pt`, or `en`)  [more info below](#locale-option)                     |               optional               | Allow to display fee plans specific for a country. Example: you're selling in France and Germany, the credit options are only available in France, so you can specify this option to 'fr' to show credits on the widget for french customers.Both options offer the same result, they allow to simplify the integration if there is no information about customer's shipping address.                                                                                                                                                                                     |
+ | customerShippingCountry |                  `string` (e.g `fr` or `es` or  `it` or `de` or `nl` or `pt`, or `en`)      [more info below](#locale-option)                   |               optional               | Allow to display fee plans specific for a country. Example: you're selling in France and Germany, the credit options are only available in France, so you can specify this option to 'fr' to show credits on the widget for french customers.Both options offer the same result, they allow to simplify the integration if there is no information about customer's shipping address.                                                                                                                                                                                     |
+ | hideBorder              |                                                                    `boolean`                                                                    | optional  (default value is `false`) | Hide the border if set to true, set to false as default                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+ | cards                   |                                   `cb` and/or `visa` and/or `amex` and/or `mastercard` as an array of strings                                   |               optional               | Display card logos in the modal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+ | onModalClose            |                                                                 (event) => void                                                                 |               optional               | Call back that will be called when the modal is closed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
-Your container's selector
-
-- purchaseAmount: `number` [required]
-
-The purchase amount (in euro cents)
-
-- plans: `Plan[]` [optional] : [more info below](#plan-option-plan)
-
-An array of the plans you want to display. If not provided, the widget returns all your available payment plans.
-
-- transitionDelay: `number` [optional, default: 5500]
-
-The amount of time in between button animations in ms.
-
-- locale: `fr|es|it|de|nl|pt|en` or local-country format (e.g `fr-FR|de-DE|it-IT`) [optional, default: en]
-
-- hideIfNotEligible: `boolean` [optional, default: false]
-
-Totally hides the widget if set to true and no plan matches the purchase amount.
-
-- monochrome: `boolean` [optional, default: true]
-
-If set to `false`, Alma's logo and the active payments plan will be underlined in red (#FF414D).
-
-- suggestedPaymentPlan: `number` | `number[]` [optional]
-
-Allow to choose which payment plan's tab will be displayed by default. It will have effect only if the selected plan is eligible. If an array is provided, it will select the first eligible plan from this array.
-
-```
-suggestedPaymentPlan: [10, 4],
-```
-
-In the above example, the 10 installments plan will be selected. If it's not eligible, the 4 installments plan will be selected. If the 4 installments plan is not eligible, it will select the first tab.
-When `suggestedPaymentPlan` is used, the transition is disable. Unless `transitionDelay` is specified.
-
-- customerBillingCountry: `string` (e.g `fr|es|it|de|nl|pt|en`) [optional]
-- customerShippingCountry: `string` (e.g `fr|es|it|de|nl|pt|en`) [optional]
-
-Allow to display fee plans specific for a country. Example: you're selling in France and Germany, the credit options are only available in France, so you can specify this option to 'fr' to show credits on the widget for french customers.
-Both options offer the same result, they allow to simplify the integration if there is no information about customer's shipping address.
-
-- hideBorder: `boolean` [optional, default: false]
-
-Hide the border if set to true, set to false as default
-
-- cards: `cb|visa|amex|mastercard`[] [optional]
-
-Display card logos in the modal
 
 ## Add Modal
 
@@ -90,62 +56,36 @@ const {open, close} = widgets.add(Alma.Widgets.Modal, {
 })
 ```
 
-Display a modal with the eligibles payment plans for the given purchase amount.
+Display a modal with the eligible payment plans for the given purchase amount.
 Can be open with the `clickableSelector` option or by calling the `open` methods.
 
 ### `ModalOptions`
 
-- container: `string` [required]
+| Option name             |                                                                       Type                                                                       |              Required               | Description                                                                                                                                                                                                                                                                                                                                                                           |
+|:------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| container               |                                                                     `string`                                                                     |            **required**             | Your container's selector                                                                                                                                                                                                                                                                                                                                                             |
+| purchaseAmount          |                                                                     `number`                                                                     |            **required**             | The purchase amount (in euro cents)                                                                                                                                                                                                                                                                                                                                                   |
+| plans                   |                                                 `Plan[]`   [more info below](#plan-option-plan)                                                  |              optional               | An array of the plans you want to display. If not provided, the widget returns all your available payment plans.                                                                                                                                                                                                                                                                      |
+| locale                  | `fr` or `es` or  `it` or `de` or `nl` or `pt`, or `en` or local-country format (e.g `fr-FR`, `de-DE`, `it-IT`) [more info below](#locale-option) | optional (default value is  `"en"`) | Defines the language displayed on the widgets                                                                                                                                                                                                                                                                                                                                         |
+| clickableSelector       |                                                                     `string`                                                                     | optional (default value is `null`)  | If provided, the modal will open when the element matching this query selector is clicked.                                                                                                                                                                                                                                                                                            |
+| customerBillingCountry  |                    `string` (e.g `fr` or `es` or  `it` or `de` or `nl` or `pt`, or `en`)   [more info below](#locale-option)                     |              optional               | Allow to display fee plans specific for a country. Example: you're selling in France and Germany, the credit options are only available in France, so you can specify this option to 'fr' to show credits on the widget for french customers.Both options offer the same result, they allow to simplify the integration if there is no information about customer's shipping address. |
+| customerShippingCountry |                     `string` (e.g `fr` or `es` or  `it` or `de` or `nl` or `pt`, or `en`)  [more info below](#locale-option)                     |              optional               | Allow to display fee plans specific for a country. Example: you're selling in France and Germany, the credit options are only available in France, so you can specify this option to 'fr' to show credits on the widget for french customers.Both options offer the same result, they allow to simplify the integration if there is no information about customer's shipping address. |
+| cards                   |                                   `cb` and/or `visa` and/or `amex` and/or `mastercard` as an array of strings                                    |              optional               | Display card logos in the modal                                                                                                                                                                                                                                                                                                                                                       |
+| onClose                 |                                                                 (event) => void                                                                  |              optional               | Call back that will be called when the modal is closed                                                                                                                                                                                                                                                                                                                                |
 
-Your container's selector
-
-- purchaseAmount: `number` [required]
-
-The purchase amount (in euro cents)
-
-- plans: `Plan[]` [optional] : [more info below](#plan-option-plan)
-
-An array of the plans you want to display. If not provided, the widget returns all your available payment plans.
-
-- locale: `fr|en|es|it|de|nl|pt` [optional, default: en]
-
-- clickableSelector: `string` [optional, default: null]
-
-If provided, the modal will open when the element matching this query selector is clicked.
-
-- cards: `cb|visa|amex|mastercard`[] [optional]
-
-Display card logos in the modal
-
-- customerBillingCountry: `string` (e.g `fr|es|it|de|nl|pt|en`) [optional]
-- customerShippingCountry: `string` (e.g `fr|es|it|de|nl|pt|en`) [optional]
-
-Allow to display fee plans specific for a country. Example: you're selling in France and Germany, the credit options are only available in France, so you can specify this option to 'fr' to show credits on the widget for french customers.
-Both options offer the same result, they allow to simplify the integration if there is no information about customer's shipping address.
 
 ## Plan option: `Plan`
 
 You can customize the displayed plans with this parameter. You can hide a plan that would be displayed otherwise by adding the other plans with this information:
 
-- installmentsCount: `number` [required]:
+| Option name       |   Type   |   Required   | Description                                                               |
+|:------------------|:--------:|:------------:|:--------------------------------------------------------------------------|
+| installmentsCount | `number` | **required** | The number of installment in the plan                                     |
+| minAmount         | `number` | **required** | The minimum purchase amount required to activate the plan (in euro cents) |
+| maxAmount         | `number` | **required** | The maximum purchase amount required to activate the plan (in euro cents) |
+| deferredDays      | `number` |   optional   | The number of days by which the first payment will be deferred            |
+| deferredMonths    | `number` |   optional   | The number of months by which the first payment will be deferred          |
 
-the number of installment in the plan
-
-- minAmount: `number` [required]
-
-the minimum purchase amount required to activate the plan (in euro cents)
-
-- maxAmount: `number` [required]
-
-the minimum purchase amount allowed to activate the plan (in euro cents)
-
-- deferredDays: `number` [optional]:
-
-the number of days by which the first payment will be deferred
-
-- deferredMonths: `number` [optional]
-
-the number of months by which the first payment will be deferred
 
 By default, the widget will display all your available payment plans.
 
@@ -154,3 +94,28 @@ By default, the widget will display all your available payment plans.
 If you want to customize the look of the widget, you can edit all classes that start with `alma-`
 
 You can see the list by inspecting the element with your dev tools. Don't use the classes that have an unpronounceable name, they will change at each new version of the widget.
+
+## Locale option
+
+The locales supported by the widgets are :
+
+*   `en` - Generic English - This is the locale set by default.
+*   `fr` - Generic French
+*   `fr-FR` - French from France
+*   `de` - Generic German
+*   `de-DE` - German from Germany
+*   `it` - Generic Italian
+*   `it-IT` - Italian from Italy
+*   `es` - Generic Spanish
+*   `es-ES` - Spanish from Spain
+*   `pt` - Generic Portuguese
+*   `pt-PT` - Portuguese from Portugal
+*   `nl` - Generic Dutch
+*   `nl-NL` Dutch from The Netherlands
+*   `nl-BE` Dutch from Belgium
+
+If the specific locale for the country you target is available, we suggest to use it instead of the generic locale.
+
+The locale is used in the Widgets to display all wordings in the correct language but also to format numbers, dates, currencies into the standard format.
+
+For example, for a pricing, the locale `pt` will format as `€ 100,00` while the locale `pt-PT` will format as `100,00 €`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@rollup/plugin-image": "^2.0.5",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.2",
+        "@testing-library/user-event": "^14.4.3",
         "@types/classnames": "^2.3.1",
         "@types/jest": "^26.0.16",
         "@types/no-scroll": "^2.1.0",
@@ -5113,6 +5114,19 @@
       "peerDependencies": {
         "react": "<18.0.0",
         "react-dom": "<18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -25019,6 +25033,13 @@
         "@testing-library/dom": "^8.0.0",
         "@types/react-dom": "<18.0.0"
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@rollup/plugin-image": "^2.0.5",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.2",
+    "@testing-library/user-event": "^14.4.3",
     "@types/classnames": "^2.3.1",
     "@types/jest": "^26.0.16",
     "@types/no-scroll": "^2.1.0",

--- a/src/Widgets/EligibilityModal/ModalContainer.tsx
+++ b/src/Widgets/EligibilityModal/ModalContainer.tsx
@@ -9,7 +9,7 @@ type Props = {
   configPlans?: ConfigPlan[]
   customerBillingCountry?: string
   customerShippingCountry?: string
-  onClose: () => void
+  onClose: (event: React.MouseEvent | React.KeyboardEvent) => void
   cards?: Card[]
 }
 

--- a/src/Widgets/EligibilityModal/__tests__/Basics.test.tsx
+++ b/src/Widgets/EligibilityModal/__tests__/Basics.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Context as ResponsiveContext } from 'react-responsive'
 import render from 'test'
@@ -6,15 +7,15 @@ import { mockButtonPlans } from 'test/fixtures'
 import { apiStatus } from 'types'
 import EligibilityModal from '..'
 
+const onClose = jest.fn()
+
 beforeEach(async () => {
   render(
     <ResponsiveContext.Provider value={{ width: 801 }}>
       <EligibilityModal
         eligibilityPlans={mockButtonPlans}
         status={apiStatus.SUCCESS}
-        onClose={() => {
-          console.log('modal closed')
-        }}
+        onClose={onClose}
       />
     </ResponsiveContext.Provider>,
   )
@@ -30,10 +31,7 @@ describe('Test responsiveness', () => {
 
 describe('onClose event test', () => {
   it('should be launched when close button is clicked', () => {
-    console.log = jest.fn()
-    act(() => {
-      fireEvent.click(screen.getByTestId('modal-close-button'))
-    })
-    expect(console.log).toBeCalledWith('modal closed')
+    userEvent.click(screen.getByTestId('modal-close-button'))
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/Widgets/EligibilityModal/__tests__/Basics.test.tsx
+++ b/src/Widgets/EligibilityModal/__tests__/Basics.test.tsx
@@ -30,8 +30,8 @@ describe('Test responsiveness', () => {
 })
 
 describe('onClose event test', () => {
-  it('should be launched when close button is clicked', () => {
-    userEvent.click(screen.getByTestId('modal-close-button'))
+  it('should be launched when close button is clicked', async () => {
+    await userEvent.click(screen.getByTestId('modal-close-button'))
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/Widgets/EligibilityModal/index.tsx
+++ b/src/Widgets/EligibilityModal/index.tsx
@@ -14,7 +14,7 @@ import MobileModal from './MobileModal'
 
 type Props = {
   initialPlanIndex?: number
-  onClose: () => void
+  onClose: (event: React.MouseEvent | React.KeyboardEvent) => void
   eligibilityPlans: EligibilityPlan[]
   status: apiStatus
   cards?: Card[]

--- a/src/Widgets/PaymentPlans/__tests__/LaunchModal.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/LaunchModal.test.tsx
@@ -1,4 +1,5 @@
-import { act, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { ApiMode } from 'consts'
 import React from 'react'
 import render from 'test'
@@ -21,13 +22,12 @@ describe('Modal initializes with the correct plan', () => {
     )
 
     await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
-    act(() => {
-      fireEvent.mouseEnter(screen.getByText('3x'))
-    })
+
+    await userEvent.hover(screen.getByText('3x'))
+
     expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
-    act(() => {
-      fireEvent.click(screen.getByTestId('widget-button'))
-    })
+
+    await userEvent.click(screen.getByTestId('widget-button'))
 
     await checkModalElements()
   })
@@ -40,14 +40,13 @@ describe('Modal initializes with the correct plan', () => {
       />,
     )
     await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
-    act(() => {
-      fireEvent.mouseOver(screen.getByText('3x'))
-    })
+
+    await userEvent.hover(screen.getByText('3x'))
+
     expect(screen.getByText('151,35 € puis 2 x 150,00 €')).toBeInTheDocument()
 
-    act(() => {
-      fireEvent.click(screen.getByText('3x'))
-    })
+    await userEvent.click(screen.getByText('3x'))
+
     await checkModalElements()
   })
 
@@ -59,15 +58,34 @@ describe('Modal initializes with the correct plan', () => {
       />,
     )
     await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
-    act(() => {
-      fireEvent.click(screen.getByTestId('widget-button'))
-    })
+
+    await userEvent.click(screen.getByTestId('widget-button'))
+
     expect(screen.getByText(/450,00 € à payer le 21 novembre 2021/)).toBeInTheDocument()
     expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
     expect(screen.getByTestId('modal-close-button')).toBeInTheDocument()
     const modalContainer = screen.getByTestId('modal-container')
     expect(within(modalContainer).getByText('21 novembre 2021')).toBeInTheDocument()
     expect(within(modalContainer).getAllByText('450,00 €')).toHaveLength(2)
+  })
+  it('should call onModalClose on close', async () => {
+    const onModalClose = jest.fn()
+    render(
+      <PaymentPlanWidget
+        purchaseAmount={40000}
+        apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
+        onModalClose={onModalClose}
+      />,
+    )
+    await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByTestId('widget-button'))
+
+    expect(screen.getByTestId('modal-close-button')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('modal-close-button'))
+
+    expect(onModalClose).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -23,6 +23,7 @@ type Props = {
   suggestedPaymentPlan?: number | number[]
   cards?: Card[]
   hideBorder?: boolean
+  onModalClose?: (event: React.MouseEvent | React.KeyboardEvent) => void
 }
 
 const VERY_LONG_TIME_IN_MS = 1000 * 3600
@@ -40,6 +41,7 @@ const PaymentPlanWidget: VoidFunctionComponent<Props> = ({
   customerShippingCountry,
   transitionDelay,
   hideBorder = false,
+  onModalClose,
 }) => {
   const [eligibilityPlans, status] = useFetchEligibility(
     purchaseAmount,
@@ -57,7 +59,10 @@ const PaymentPlanWidget: VoidFunctionComponent<Props> = ({
   const isTransitionSpecified = transitionDelay !== undefined // 👈  The merchant has specified a transition time
   const [isOpen, setIsOpen] = useState(false)
   const openModal = () => setIsOpen(true)
-  const closeModal = () => setIsOpen(false)
+  const closeModal = (event: React.MouseEvent | React.KeyboardEvent) => {
+    setIsOpen(false)
+    onModalClose && onModalClose(event)
+  }
 
   const eligiblePlanKeys = eligibilityPlans.reduce<number[]>(
     (acc, plan, index) => (plan.eligible ? [...acc, index] : acc),

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -10,7 +10,7 @@ import STATIC_CUSTOMISATION_CLASSES from 'Widgets/EligibilityModal/classNames.co
 export type Props = Modal.Props & {
   children: ReactNode
   isOpen: boolean
-  onClose: () => void
+  onClose: (event: React.MouseEvent | React.KeyboardEvent) => void
   className?: string
   contentClassName?: string
   scrollable?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { ApiMode } from 'consts'
+import * as React from 'react'
 
 export type ApiConfig = { domain: ApiMode; merchantId: string }
 
@@ -81,6 +82,7 @@ export type PaymentPlanWidgetOptions = {
   hideBorder?: boolean
   customerBillingCountry?: string
   customerShippingCountry?: string
+  onModalClose?: (event: React.MouseEvent | React.KeyboardEvent) => void
 }
 
 export type ModalOptions = {
@@ -92,6 +94,7 @@ export type ModalOptions = {
   plans?: ConfigPlan[]
   locale?: Locale
   cards?: Card[]
+  onClose?: (event: React.MouseEvent | React.KeyboardEvent) => void
 }
 
 export type WidgetNames = keyof typeof widgetTypes

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { ApiMode } from 'consts'
-import * as React from 'react'
+import React from 'react'
 
 export type ApiConfig = { domain: ApiMode; merchantId: string }
 

--- a/src/widgets_controller.tsx
+++ b/src/widgets_controller.tsx
@@ -16,7 +16,7 @@ import PaymentPlanWidget from 'Widgets/PaymentPlans'
 export type AddReturnType =
   | {
       open: () => void
-      close: () => void
+      close: (event: React.MouseEvent | React.KeyboardEvent) => void
     }
   | undefined
 
@@ -44,6 +44,7 @@ export class WidgetsController {
         customerShippingCountry,
         locale = Locale.en,
         cards,
+        onModalClose,
       } = options as PaymentPlanWidgetOptions
 
       if (containerDiv) {
@@ -61,6 +62,7 @@ export class WidgetsController {
               customerShippingCountry={customerShippingCountry}
               transitionDelay={transitionDelay}
               hideBorder={hideBorder}
+              onModalClose={onModalClose}
             />
           </IntlProvider>,
           document.querySelector(container),
@@ -78,10 +80,14 @@ export class WidgetsController {
         customerBillingCountry,
         customerShippingCountry,
         cards,
+        onClose,
       } = options as ModalOptions
 
-      const close = () => containerDiv && unmountComponentAtNode(containerDiv)
-
+      const close = (event: React.MouseEvent | React.KeyboardEvent) => {
+        if (!containerDiv) return
+        unmountComponentAtNode(containerDiv)
+        onClose && onClose(event)
+      }
       const renderModal = () => {
         render(
           <IntlProvider locale={locale}>


### PR DESCRIPTION
Allow merchant to configure a callback on Modal close.
It is configurable from the PaymentPlan Widget as well as directly from the Modal Widget.

Also:  Update documentation to make it more clear to read

Someone suggested to provide an onClose callback here https://github.com/alma/widgets/pull/112