### PR TITLE
Use userEvent instead of fireEvent

### DIFF
--- a/src/Widgets/EligibilityModal/ModalContainer.test.tsx
+++ b/src/Widgets/EligibilityModal/ModalContainer.test.tsx
@@ -1,10 +1,9 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { ApiMode } from 'consts'
 import React from 'react'
-import { act } from 'react-dom/test-utils'
 import render from 'test'
 import { mockButtonPlans } from 'test/fixtures'
-import { secondsToMilliseconds } from 'utils'
 import ModalContainer from './ModalContainer'
 import { Context as ResponsiveContext } from 'react-responsive'
 jest.mock('utils/fetch', () => {
@@ -12,8 +11,6 @@ jest.mock('utils/fetch', () => {
     fetchFromApi: async () => mockButtonPlans,
   }
 })
-
-global.Date.now = jest.fn(() => secondsToMilliseconds(1638350762))
 
 describe('ModalContainer', () => {
   describe('test responsiveness', () => {
@@ -70,10 +67,9 @@ describe('ModalContainer', () => {
       expect(element).toHaveTextContent('21 novembre 2021')
     })
 
-    it('should display the schedule for the selected payment plan', () => {
-      act(() => {
-        fireEvent.click(screen.getByText('4x'))
-      })
+    it('should display the schedule for the selected payment plan', async () => {
+      await userEvent.click(screen.getByText('4x'))
+
       const installmentElement = screen.getByTestId('modal-container')
       const totalElement = screen.getByTestId('modal-summary')
       const expectedInstallments = [

--- a/src/Widgets/EligibilityModal/__tests__/ModalContainer.test.tsx
+++ b/src/Widgets/EligibilityModal/__tests__/ModalContainer.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Widgets } from 'index'
 import { ApiMode } from 'consts'
 import React from 'react'
@@ -28,13 +29,13 @@ describe('ModalContainer', () => {
   it('should open with clickableSelector and open method', async () => {
     console.error = jest.fn()
     const openModalButton = screen.getByText('Open modal with clickableSelector')
-    fireEvent.click(openModalButton)
+    await userEvent.click(openModalButton)
     expect(screen.getByTestId('modal-close-button')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('modal-close-button'))
+    await userEvent.click(screen.getByTestId('modal-close-button'))
 
     ModalWidget?.open()
     await waitFor(() => expect(screen.queryByTestId('modal-close-button')).toBeInTheDocument())
-    ModalWidget?.close()
+    ModalWidget?.close({} as React.MouseEvent)
     await waitFor(() => expect(screen.queryByTestId('modal-close-button')).not.toBeInTheDocument())
   })
 })

--- a/src/Widgets/EligibilityModal/__tests__/Plans.test.tsx
+++ b/src/Widgets/EligibilityModal/__tests__/Plans.test.tsx
@@ -1,12 +1,10 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
-import secondsToMilliseconds from 'date-fns/secondsToMilliseconds'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import render from 'test'
 import { mockPlansAllEligible, mockPlansWithoutDeferred } from 'test/fixtures'
 import { apiStatus } from 'types'
 import EligibilityModal from '..'
-
-global.Date.now = jest.fn(() => secondsToMilliseconds(1638350762))
 
 describe('plans provided', () => {
   describe('default behaviour', () => {
@@ -56,8 +54,8 @@ describe('plans provided', () => {
       expect(totalElement).toHaveTextContent('Total')
       expect(totalElement).toHaveTextContent('Dont frais')
     })
-    it('should display the schedule for the selected payment plan', () => {
-      fireEvent.click(screen.getByText('4x'))
+    it('should display the schedule for the selected payment plan', async () => {
+      await userEvent.click(screen.getByText('4x'))
       const installmentElement = screen.getByTestId('modal-installments-element')
 
       expect(installmentElement).toHaveTextContent("Aujourd'hui")
@@ -72,8 +70,8 @@ describe('plans provided', () => {
       expect(totalElement).toHaveTextContent('Total')
       expect(totalElement).toHaveTextContent('460,62 €')
     })
-    it('should display credit specific features', () => {
-      fireEvent.click(screen.getByText('10x'))
+    it('should display credit specific features', async () => {
+      await userEvent.click(screen.getByText('10x'))
       const totalElement = screen.getByTestId('modal-summary')
       expect(totalElement).toHaveTextContent('Dont coût du crédit')
       expect(totalElement).toHaveTextContent('26,64 € (TAEG 17,2 %)')

--- a/src/Widgets/PaymentPlans/__tests__/Basics.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/Basics.test.tsx
@@ -1,4 +1,5 @@
-import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { ApiMode } from 'consts'
 import React from 'react'
 import render from 'test'
@@ -27,9 +28,9 @@ describe('Basic PaymentPlan test', () => {
   })
 
   it('opens the modal on click and close it', async () => {
-    fireEvent.click(screen.getByTestId('widget-button'))
+    await userEvent.click(screen.getByTestId('widget-button'))
     expect(screen.getByTestId('modal-close-button')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('modal-close-button'))
+    await userEvent.click(screen.getByTestId('modal-close-button'))
     expect(screen.queryByTestId('modal-close-button')).not.toBeInTheDocument()
   })
   describe('PayNow handle', () => {

--- a/src/Widgets/PaymentPlans/__tests__/IneligibleOptions.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/IneligibleOptions.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { ApiMode } from 'consts'
 import React from 'react'
 import render from 'test'
@@ -10,11 +11,18 @@ jest.mock('utils/fetch', () => {
     fetchFromApi: async () => mockEligibilityPaymentPlanWithIneligiblePlan,
   }
 })
-jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01').getTime())
 
 const animationDuration = 5600
 
 describe('PaymentPlan has ineligible options from configPlans', () => {
+  beforeAll(() => {
+    jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01').getTime())
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   beforeEach(async () => {
     render(
       <PaymentPlanWidget
@@ -66,8 +74,10 @@ describe('PaymentPlan has ineligible options from configPlans', () => {
     expect(screen.getByText('2 x 225,00 € (sans frais)')).toBeInTheDocument()
   })
 
-  it('display conditions when inactive plans are hovered', () => {
-    fireEvent.mouseEnter(screen.getByText('4x'))
+  it('display conditions when inactive plans are hovered', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    await user.hover(screen.getByText('4x'))
     expect(screen.getByText("Jusqu'à 150,00 €")).toBeInTheDocument()
   })
 })
@@ -95,10 +105,12 @@ describe('PaymentPlan has ineligible options from merchant config', () => {
     await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
   })
 
-  it('display conditions when non eligible plans are hovered', () => {
-    fireEvent.mouseEnter(screen.getByText('10x'))
+  it('display conditions when non eligible plans are hovered', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    await user.hover(screen.getByText('10x'))
     expect(screen.getByText('À partir de 900,00 €')).toBeInTheDocument()
-    fireEvent.mouseEnter(screen.getByText('4x'))
+    await user.hover(screen.getByText('4x'))
     expect(screen.getByText("Jusqu'à 200,00 €")).toBeInTheDocument()
   })
 })

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,5 +3,11 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect'
+import secondsToMilliseconds from 'date-fns/secondsToMilliseconds'
 
 jest.mock('no-scroll', () => ({ on: jest.fn(), off: jest.fn() }))
+
+beforeEach(() => {
+  // Mock jest's "Today"
+  Date.now = jest.fn(() => secondsToMilliseconds(1638350762)) // 01.12.2021
+})


### PR DESCRIPTION
react-testing-library best practices suggest to use `userEvent` instead of `fireEvent` in tests. This PR update tests to make them more modern/clean to avoid technical debt