### PR TITLE
Change "payez" to "payer" for pay now

### DIFF
--- a/src/Widgets/EligibilityModal/__tests__/Plans.test.tsx
+++ b/src/Widgets/EligibilityModal/__tests__/Plans.test.tsx
@@ -36,7 +36,7 @@ describe('plans provided', () => {
       )
     })
     it('should display the payments plans provided in eligibility', () => {
-      expect(screen.getByText('Payez maintenant')).toBeInTheDocument()
+      expect(screen.getByText('Payer maintenant')).toBeInTheDocument()
       expect(screen.getByText('M+1')).toBeInTheDocument()
       expect(screen.getByText('2x')).toBeInTheDocument()
       expect(screen.getByText('3x')).toBeInTheDocument()
@@ -102,7 +102,7 @@ describe('plans provided', () => {
         'Payez en une fois par carte bancaire avec Alma.',
       )
       expect(screen.getByTestId('modal-info-element')).toHaveTextContent(
-        'Choisissez Alma - Payez maintenant au moment du paiement.',
+        'Choisissez Alma - Payer maintenant au moment du paiement.',
       )
       expect(screen.getByTestId('modal-info-element')).toHaveTextContent(
         'Renseignez les informations de votre carte bancaire.',

--- a/src/Widgets/EligibilityModal/components/Info/index.tsx
+++ b/src/Widgets/EligibilityModal/components/Info/index.tsx
@@ -14,7 +14,7 @@ const Info: FC<{ isCurrentPlanP1X: boolean }> = ({ isCurrentPlanP1X }) => (
         {isCurrentPlanP1X ? (
           <FormattedMessage
             id="eligibility-modal.p1x-bullet-1"
-            defaultMessage="Choisissez <strong>Alma - Payez maintenant</strong> au moment du paiement."
+            defaultMessage="Choisissez <strong>Alma - Payer maintenant</strong> au moment du paiement."
             values={{ strong: (...chunks: string[]) => <strong>{chunks}</strong> }}
           />
         ) : (

--- a/src/Widgets/PaymentPlans/__tests__/Basics.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/Basics.test.tsx
@@ -43,7 +43,7 @@ describe('Basic PaymentPlan test', () => {
         />,
       )
       await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
-      expect(screen.queryByText(/Payez maintenant 450,00 €/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Payer maintenant 450,00 €/)).not.toBeInTheDocument()
       expect(screen.getByText(/2 x 225,00 €/)).toBeInTheDocument()
     })
     it('should display P1X button if specifically asked for from widgets config', async () => {
@@ -64,7 +64,7 @@ describe('Basic PaymentPlan test', () => {
       )
       await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
       expect(screen.queryByText(/2 x 225,00 €/)).not.toBeInTheDocument()
-      expect(screen.getByText(/Payez maintenant 450,00 €/)).toBeInTheDocument()
+      expect(screen.getByText(/Payer maintenant 450,00 €/)).toBeInTheDocument()
     })
   })
 })

--- a/src/Widgets/PaymentPlans/__tests__/CustomTransitionDelay.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/CustomTransitionDelay.test.tsx
@@ -34,7 +34,7 @@ describe('Custom transition delay', () => {
       jest.advanceTimersByTime(animationDuration)
     })
     // P1X
-    expect(screen.getByText(/Payez maintenant 450,00 €/)).toBeInTheDocument()
+    expect(screen.getByText(/Payer maintenant 450,00 €/)).toBeInTheDocument()
     expect(screen.getByText(/(sans frais)/)).toBeInTheDocument()
     act(() => {
       jest.advanceTimersByTime(animationDuration)

--- a/src/Widgets/PaymentPlans/__tests__/SuggestedPaymentPlan.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/SuggestedPaymentPlan.test.tsx
@@ -37,8 +37,8 @@ describe('PaymentPlan has suggestedPaymentPlan', () => {
     it('should target the P1X and not a PayLater plan when suggested plan is 1', async () => {
       renderPlans(1, configPlans) // specify all plans explicitly to display P1X. P1X is only displayed if provided in configPlans.
       await waitFor(() => expect(screen.getByTestId('widget-button')).toBeInTheDocument())
-      expect(screen.getByText(/Payez maintenant 450,00 €/)).toBeInTheDocument()
-      expect(screen.getByText('Payez maintenant').className).toContain('active')
+      expect(screen.getByText(/Payer maintenant 450,00 €/)).toBeInTheDocument()
+      expect(screen.getByText('Payer maintenant').className).toContain('active')
     })
   })
 

--- a/src/Widgets/PaymentPlans/__tests__/WithoutPlans.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/WithoutPlans.test.tsx
@@ -28,7 +28,7 @@ describe('No plans provided', () => {
 
   it('displays all available payment plans', () => {
     expect(screen.getByText('M+1')).toBeInTheDocument()
-    expect(screen.queryByText('Payez maintenant')).not.toBeInTheDocument() // By default P1X is filtered
+    expect(screen.queryByText('Payer maintenant')).not.toBeInTheDocument() // By default P1X is filtered
     expect(screen.getByText('2x')).toBeInTheDocument()
     expect(screen.getByText('3x')).toBeInTheDocument()
     expect(screen.getByText('4x')).toBeInTheDocument()

--- a/src/intl/messages.json
+++ b/src/intl/messages.json
@@ -6,7 +6,7 @@
   "eligibility-modal.bullet-2": "Laissez-vous guider et validez votre paiement en <strong>2 minutes.</strong>",
   "eligibility-modal.bullet-3": "<strong>Gardez le contrôle</strong> en avançant ou reculant vos échéances à votre rythme.",
   "eligibility-modal.no-eligibility": "Oups, il semblerait que la simulation n'ait pas fonctionné.",
-  "eligibility-modal.p1x-bullet-1": "Choisissez <strong>Alma - Payez maintenant</strong> au moment du paiement.",
+  "eligibility-modal.p1x-bullet-1": "Choisissez <strong>Alma - Payer maintenant</strong> au moment du paiement.",
   "eligibility-modal.p1x-bullet-2": "Renseignez les informations de votre <strong>carte bancaire.</strong>",
   "eligibility-modal.p1x-bullet-3": "<strong>La validation </strong> de votre paiement est instantanée !",
   "eligibility-modal.title-deferred-plan": "Payez en plusieurs fois ou plus tard par carte bancaire avec Alma.",
@@ -24,6 +24,6 @@
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(sans frais)",
-  "payment-plan-strings.pay-now": "Payez maintenant {totalAmount}",
-  "payment-plan-strings.pay.now.button": "Payez maintenant"
+  "payment-plan-strings.pay-now": "Payer maintenant {totalAmount}",
+  "payment-plan-strings.pay.now.button": "Payer maintenant"
 }

--- a/src/intl/messages/messages.de.json
+++ b/src/intl/messages/messages.de.json
@@ -24,6 +24,6 @@
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} dann {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} dann {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(0% Finanzierung)",
-  "payment-plan-strings.pay-now": "Zahlen Sie jetzt {totalAmount}",
+  "payment-plan-strings.pay-now": "Jetzt bezahlen {totalAmount}",
   "payment-plan-strings.pay.now.button": "Jetzt bezahlen"
 }

--- a/src/intl/messages/messages.en.json
+++ b/src/intl/messages/messages.en.json
@@ -6,7 +6,7 @@
   "eligibility-modal.bullet-2": "Let us guide you and validate your payment in <strong>2 minutes.</strong>",
   "eligibility-modal.bullet-3": "<strong>Stay in control</strong> by moving your deadlines forward or backward at your own pace.",
   "eligibility-modal.no-eligibility": "Oops, looks like the simulation didn't work.",
-  "eligibility-modal.p1x-bullet-1": "Choose <strong>Alma - Pay Now</strong> at checkout.",
+  "eligibility-modal.p1x-bullet-1": "Choose <strong>Alma - Pay now</strong> at checkout.",
   "eligibility-modal.p1x-bullet-2": "Fill in your <strong>credit card information.</strong>",
   "eligibility-modal.p1x-bullet-3": "<strong>The validation </strong> of your payment is instantaneous!",
   "eligibility-modal.title-deferred-plan": "Pay in installments or later by credit card with Alma.",
@@ -25,5 +25,5 @@
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(free of charge)",
   "payment-plan-strings.pay-now": "Pay now {totalAmount}",
-  "payment-plan-strings.pay.now.button": "Pay Now"
+  "payment-plan-strings.pay.now.button": "Pay now"
 }

--- a/src/intl/messages/messages.fr.json
+++ b/src/intl/messages/messages.fr.json
@@ -6,7 +6,7 @@
   "eligibility-modal.bullet-2": "Laissez-vous guider et validez votre paiement en <strong>2 minutes.</strong>",
   "eligibility-modal.bullet-3": "<strong>Gardez le contrôle</strong> en avançant ou reculant vos échéances à votre rythme.",
   "eligibility-modal.no-eligibility": "Oups, il semblerait que la simulation n'ait pas fonctionné.",
-  "eligibility-modal.p1x-bullet-1": "Choisissez <strong>Alma - Payez maintenant</strong> au moment du paiement.",
+  "eligibility-modal.p1x-bullet-1": "Choisissez <strong>Alma - Payer maintenant</strong> au moment du paiement.",
   "eligibility-modal.p1x-bullet-2": "Renseignez les informations de votre <strong>carte bancaire.</strong>",
   "eligibility-modal.p1x-bullet-3": "<strong>La validation </strong> de votre paiement est instantanée !",
   "eligibility-modal.title-deferred-plan": "Payez en plusieurs fois ou plus tard par carte bancaire avec Alma.",
@@ -24,6 +24,6 @@
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(sans frais)",
-  "payment-plan-strings.pay-now": "Payez maintenant {totalAmount}",
-  "payment-plan-strings.pay.now.button": "Payez maintenant"
+  "payment-plan-strings.pay-now": "Payer maintenant {totalAmount}",
+  "payment-plan-strings.pay.now.button": "Payer maintenant"
 }

--- a/src/intl/messages/messages.nl.json
+++ b/src/intl/messages/messages.nl.json
@@ -7,7 +7,6 @@
   "eligibility-modal.bullet-3": "<strong>Behoudt de controle</strong> door jouw deadlines op je eigen tempo vooruit of achteruit te schuiven.",
   "eligibility-modal.no-eligibility": "Oeps, het lijkt erop dat de simulatie niet werkte.",
   "eligibility-modal.p1x-bullet-1": "Kies <strong>Alma - Betaal nu</strong> bij het afrekenen.",
-  "eligibility-modal.p1x-bullet-1": "Kies <strong>Alma - Betaal nu</strong> bij het afrekenen.",
   "eligibility-modal.p1x-bullet-2": "Vul jouw <strong>creditcardgegevens </strong> in.",
   "eligibility-modal.p1x-bullet-3": "<strong>De bevestiging </strong> van jouw betaling is onmiddellijk!",
   "eligibility-modal.title-deferred-plan": "Betaal in termijnen of later via iDEAL of per creditcard met Alma.",

--- a/src/intl/messages/messages.pt.json
+++ b/src/intl/messages/messages.pt.json
@@ -24,6 +24,6 @@
   "payment-plan-strings.multiple-installments": "{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} depois {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} depois {numberOfRemainingInstallments} x {othersInstallmentAmount}}}",
   "payment-plan-strings.multiple-installments-same-amount": "{installmentsCount} x {totalAmount}",
   "payment-plan-strings.no-fee": "(sem encargos)",
-  "payment-plan-strings.pay-now": "Pague agora {totalAmount}",
+  "payment-plan-strings.pay-now": "Pagar agora {totalAmount}",
   "payment-plan-strings.pay.now.button": "Pagar agora"
 }

--- a/src/utils/index.test.tsx
+++ b/src/utils/index.test.tsx
@@ -40,7 +40,7 @@ describe('utils', () => {
            expect(paymentPlanShorthandName(plan)).toEqual(
              <FormattedMessage
                id="payment-plan-strings.pay.now.button"
-               defaultMessage="Payez maintenant"
+               defaultMessage="Payer maintenant"
              />
            )
         })

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -11,7 +11,7 @@ export const paymentPlanShorthandName = (payment: EligibilityPlan): ReactNode =>
     return (
       <FormattedMessage
         id="payment-plan-strings.pay.now.button"
-        defaultMessage="Payez maintenant"
+        defaultMessage="Payer maintenant"
         
       />
     )
@@ -135,7 +135,7 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
         <>
           <FormattedMessage
             id="payment-plan-strings.pay-now"
-            defaultMessage="Payez maintenant {totalAmount}"
+            defaultMessage="Payer maintenant {totalAmount}"
             values={{
               totalAmount: (
                 <FormattedNumber


### PR DESCRIPTION
Quick wording change for pay now

https://linear.app/almapay/issue/MPP-327/pay-now-change-payez-for-payer