### PR TITLE
Disable dynamic FeePlan change if transitionDelay equals -1

### DIFF
--- a/src/hooks/useButtonAnimation.ts
+++ b/src/hooks/useButtonAnimation.ts
@@ -15,7 +15,7 @@ const useButtonAnimation = (iterateValues: number[], transitionDelay: number): P
     if (iterateValues.length !== 0) {
       if (!iterateValues.includes(current) && update) setCurrent(iterateValues[0])
       timeout = setTimeout(() => {
-        if (update && isMounted) {
+        if (update && isMounted && transitionDelay !== -1) {
           setCurrent(
             iterateValues[
               iterateValues.includes(current)


### PR DESCRIPTION
Merchants want to be able to disable the dynamic change of FeePlan.

Now if transitionDelay = -1 it is the case.

Ticket : (https://linear.app/almapay/issue/MPP-710/allow-to-disable-the-dynamic-feeplan-change-with-transitiondelay-=-1)

### How to test 
In the basic.html file (ou multiple.html), add `transitionDelay = -1` in the renderPaymentPlans function. The feePlan should not change.