### PR TITLE
Add renovate, dependabot configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# This file is only used for vulnerability alerts for NPM, not for automatic updates.
+# Renovate has trouble patching NPM lockfile-only vulnerabilities.
+
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 0  # only allow vulnerabilities
+    groups:
+      npm-vulnerabilities:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - "type: security"
+    reviewers:
+      - alma/squad-e-commerce-integrations
+      - alma/it-and-security-operation

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
     "github>alma/renovate:vulnerabilities"
   ],
   "separateMinorPatch": true,
+  "dependencyDashboard": true,
   "packageRules": [
     {
       "matchManagers": ["npm"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "prHourlyLimit": 20,
+  "prConcurrentLimit": 20,
+  "recreateWhen": "always",
+  "enabledManagers": ["github-actions", "nvm", "npm"],
+  "reviewers": ["team:squad-e-commerce-integrations"],
+  "extends": [
+    "github>alma/renovate:github-actions",
+    "github>alma/renovate:confidence-badges",
+    "github>alma/renovate:vulnerabilities"
+  ],
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "groupName": "NPM dependencies",
+      "reviewers": ["team:squad-e-commerce-integrations"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Add:
* Renovate configuration for dependency maintenance on `npm`, `nvm` and `github-actions`
* Dependabot configuration for lockfile-only NPM vulnerabilities that Renovate is not able to patch