### PR TITLE
Improve credit wordings

### DIFF
--- a/src/Widgets/EligibilityModal/__tests__/Plans.test.tsx
+++ b/src/Widgets/EligibilityModal/__tests__/Plans.test.tsx
@@ -75,10 +75,9 @@ describe('plans provided', () => {
       const totalElement = screen.getByTestId('modal-summary')
       expect(totalElement).toHaveTextContent('Dont coût du crédit')
       expect(totalElement).toHaveTextContent('26,64 € (TAEG 17,2 %)')
+      expect(screen.getByText('Un crédit vous engage et doit être remboursé.')).toBeInTheDocument()
       expect(
-        screen.getByText(
-          'Un crédit vous engage et doit être remboursé. Vérifiez vos capacités de remboursement avant de vous engager.',
-        ),
+        screen.getByText('Vérifiez vos capacités de remboursement avant de vous engager.'),
       ).toBeInTheDocument()
     })
   })

--- a/src/Widgets/EligibilityModal/components/Schedule/Schedule.module.css
+++ b/src/Widgets/EligibilityModal/components/Schedule/Schedule.module.css
@@ -4,11 +4,6 @@
   font-family: 'Venn', sans-serif;
 }
 
-.creditInfo {
-  font-size: 14px;
-  margin-left: 4px;
-}
-
 @media (min-width: 800px) {
   .schedule {
     overflow-y: auto;

--- a/src/Widgets/EligibilityModal/components/Schedule/index.tsx
+++ b/src/Widgets/EligibilityModal/components/Schedule/index.tsx
@@ -1,6 +1,5 @@
 import cx from 'classnames'
 import React, { FC } from 'react'
-import { FormattedMessage } from 'react-intl'
 import { EligibilityPlan } from 'types'
 
 import Installment from 'components/Installments/Installment'
@@ -8,8 +7,6 @@ import STATIC_CUSTOMISATION_CLASSES from 'Widgets/EligibilityModal/classNames.co
 import s from './Schedule.module.css'
 
 const Schedule: FC<{ currentPlan: EligibilityPlan }> = ({ currentPlan }) => {
-  const isCredit = currentPlan.installments_count > 4
-
   return (
     <>
       <div
@@ -19,14 +16,6 @@ const Schedule: FC<{ currentPlan: EligibilityPlan }> = ({ currentPlan }) => {
         {(currentPlan?.payment_plan || []).map((installment, index) => (
           <Installment key={installment.due_date * 1000} installment={installment} index={index} />
         ))}
-        {isCredit && (
-          <div className={s.creditInfo}>
-            <FormattedMessage
-              id="credit-features.information"
-              defaultMessage="Un crédit vous engage et doit être remboursé. Vérifiez vos capacités de remboursement avant de vous engager."
-            />
-          </div>
-        )}
       </div>
     </>
   )

--- a/src/Widgets/PaymentPlans/__tests__/Credit.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/Credit.test.tsx
@@ -64,7 +64,7 @@ describe('PaymentPlan has credit', () => {
     await userEvent.hover(screen.getByText('3x'))
     expect(screen.getByText(/151,35 € puis 2 x 150,00 €/)).toBeInTheDocument()
     await userEvent.hover(screen.getByText('10x'))
-    expect(screen.getByText(/47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
+    expect(screen.getByText(/Cliquez pour en savoir plus/)).toBeInTheDocument()
   })
 
   it('stops iterating when an element has been hovered', async () => {

--- a/src/Widgets/PaymentPlans/__tests__/CustomTransitionDelay.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/CustomTransitionDelay.test.tsx
@@ -52,7 +52,7 @@ describe('Custom transition delay', () => {
     act(() => {
       jest.advanceTimersByTime(animationDuration)
     })
-    expect(screen.getByText(/47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
+    expect(screen.getByText(/Cliquez pour en savoir plus/)).toBeInTheDocument()
     act(() => {
       jest.advanceTimersByTime(animationDuration)
     })

--- a/src/components/Installments/Installment/Installment.module.css
+++ b/src/components/Installments/Installment/Installment.module.css
@@ -38,7 +38,7 @@
 
   .dot::after {
     border-left: 2px solid var(--off-white);
-    height: 85px;
+    height: 18px;
     margin-left: 4px;
     content: " ";
     position: absolute;

--- a/src/components/Installments/TotalBlock/TotalBlock.module.css
+++ b/src/components/Installments/TotalBlock/TotalBlock.module.css
@@ -19,6 +19,21 @@
   font-size: 20px;
 }
 
+.creditInfo {
+  margin: 4px 0;
+  font-family: 'Venn', sans-serif;
+  border-radius: 20px;
+  border: 1px solid var(--off-white);
+  padding: 16px;
+  z-index: 2;
+  position: relative;
+  font-size: 16px;
+}
+
+.creditInfoTitle {
+  font-weight: var(--weight-bold);
+}
+
 .fees {
   display: flex;
   font-family: 'Venn', sans-serif;
@@ -31,4 +46,11 @@
 
 .creditCost {
   text-align: right;
+}
+
+.creditInfoLegalText {
+  font-size: 10px;
+  font-family: 'Venn', sans-serif;
+  margin-top: 8px;
+  font-weight: var(--weight-normal);
 }

--- a/src/components/Installments/TotalBlock/index.tsx
+++ b/src/components/Installments/TotalBlock/index.tsx
@@ -15,52 +15,80 @@ const TotalBlock: FunctionComponent<{ currentPlan: EligibilityPlan }> = ({ curre
   const isCredit = currentPlan.installments_count > 4
 
   return (
-    <div
-      className={cx(s.container, STATIC_CUSTOMISATION_CLASSES.summary)}
-      data-testid="modal-summary"
-    >
-      <div className={cx(s.total, STATIC_CUSTOMISATION_CLASSES.scheduleTotal)}>
-        <FormattedMessage tagName="div" id="installments.total-amount" defaultMessage="Total" />
-        <FormattedNumber value={total || 0} style="currency" currency="EUR" />
-      </div>
-      <div className={cx(s.fees, STATIC_CUSTOMISATION_CLASSES.scheduleCredit)}>
-        {isCredit ? (
-          <>
+    <>
+      {isCredit && (
+        <div className={s.creditInfo}>
+          <span className={s.creditInfoTitle}>
             <FormattedMessage
-              id="credit-features.total-credit-cost"
-              defaultMessage="Dont coût du crédit"
+              id="credit-features.information.title"
+              defaultMessage="Un crédit vous engage et doit être remboursé."
             />
-            <span className={s.creditCost}>
+          </span>
+          <br />
+          <FormattedMessage
+            id="credit-features.information"
+            defaultMessage="Vérifiez vos capacités de remboursement avant de vous engager."
+          />
+        </div>
+      )}
+      <div
+        className={cx(s.container, STATIC_CUSTOMISATION_CLASSES.summary)}
+        data-testid="modal-summary"
+      >
+        <div className={cx(s.total, STATIC_CUSTOMISATION_CLASSES.scheduleTotal)}>
+          <FormattedMessage tagName="div" id="installments.total-amount" defaultMessage="Total" />
+          <FormattedNumber value={total || 0} style="currency" currency="EUR" />
+        </div>
+        <div className={cx(s.fees, STATIC_CUSTOMISATION_CLASSES.scheduleCredit)}>
+          {isCredit ? (
+            <>
               <FormattedMessage
-                id="credit-features.credit-cost-display"
-                defaultMessage="{creditCost} (TAEG {taegPercentage})"
-                values={{
-                  creditCost: intl.formatNumber(creditCost, {
-                    style: 'currency',
-                    currency: 'EUR',
-                  }),
-                  taegPercentage: intl.formatNumber(TAEG, {
-                    style: 'percent',
-                    maximumFractionDigits: 2,
-                  }),
-                }}
+                id="credit-features.total-credit-cost"
+                defaultMessage="Dont coût du crédit"
               />
-            </span>
-          </>
-        ) : (
-          <>
+              <span className={s.creditCost}>
+                <FormattedMessage
+                  id="credit-features.credit-cost-display"
+                  defaultMessage="{creditCost} (TAEG {taegPercentage})"
+                  values={{
+                    creditCost: intl.formatNumber(creditCost, {
+                      style: 'currency',
+                      currency: 'EUR',
+                    }),
+                    taegPercentage: intl.formatNumber(TAEG, {
+                      style: 'percent',
+                      maximumFractionDigits: 2,
+                    }),
+                  }}
+                />
+              </span>
+            </>
+          ) : (
+            <>
+              <FormattedMessage
+                id="installments.total-fees"
+                defaultMessage="Dont frais (TTC)"
+                tagName="div"
+              />
+              <div>
+                <FormattedNumber value={customerFees} style="currency" currency="EUR" />
+              </div>
+            </>
+          )}
+        </div>
+        {
+          // TODO: Add dynamic values according to the Figma
+        }
+        {isCredit && (
+          <div className={s.creditInfoLegalText}>
             <FormattedMessage
-              id="installments.total-fees"
-              defaultMessage="Dont frais (TTC)"
-              tagName="div"
+              id="credit-features.legal-text"
+              defaultMessage="Crédit d'un montant de 668,83€ au taux débiteur fixe de 20,54% sur une durée de 9 mois. Permettant, en complément d'un acompte de 80,17€, de financer un achat d'un montant de 749€. Sous réserve d'étude et d'acceptation par Alma. Délai légal de rétractation de 14 jours. Simulation présentée par Alma, immatriculée au RCS Nanterre sous le numéro 839 100 575, établissement de paiement et société de financement agréée par l’ACPR sous le n° 17408 (numéro CIB / Code banque)."
             />
-            <div>
-              <FormattedNumber value={customerFees} style="currency" currency="EUR" />
-            </div>
-          </>
+          </div>
         )}
       </div>
-    </div>
+    </>
   )
 }
 

--- a/src/components/Installments/TotalBlock/index.tsx
+++ b/src/components/Installments/TotalBlock/index.tsx
@@ -13,6 +13,12 @@ const TotalBlock: FunctionComponent<{ currentPlan: EligibilityPlan }> = ({ curre
   const TAEG = (currentPlan?.annual_interest_rate && currentPlan.annual_interest_rate / 10000) || 0
   const customerFees = priceFromCents(currentPlan.customer_total_cost_amount)
   const isCredit = currentPlan.installments_count > 4
+  const firstInstallmentAmount = priceFromCents(currentPlan.payment_plan?.[0]?.total_amount ?? 0)
+  const totalWithoutFirstInstallment = priceFromCents(
+    currentPlan.purchase_amount +
+      currentPlan.customer_total_cost_amount -
+      (currentPlan.payment_plan?.[0]?.total_amount ?? 0),
+  )
 
   return (
     <>
@@ -83,7 +89,26 @@ const TotalBlock: FunctionComponent<{ currentPlan: EligibilityPlan }> = ({ curre
           <div className={s.creditInfoLegalText}>
             <FormattedMessage
               id="credit-features.legal-text"
-              defaultMessage="Crédit d'un montant de 668,83€ au taux débiteur fixe de 20,54% sur une durée de 9 mois. Permettant, en complément d'un acompte de 80,17€, de financer un achat d'un montant de 749€. Sous réserve d'étude et d'acceptation par Alma. Délai légal de rétractation de 14 jours. Simulation présentée par Alma, immatriculée au RCS Nanterre sous le numéro 839 100 575, établissement de paiement et société de financement agréée par l’ACPR sous le n° 17408 (numéro CIB / Code banque)."
+              defaultMessage="Crédit d'un montant de {totalWithoutFirstInstallment} au taux débiteur fixe de {taegPercentage} sur une durée de {installmeentsCountWithoutFirst} mois. Permettant, en complément d'un acompte de {firstInstallmentAmount}, de financer un achat d'un montant de {productPriceWithoutCreditCost}. Sous réserve d'étude et d'acceptation par Alma. Délai légal de rétractation de 14 jours. Simulation présentée par Alma, immatriculée au RCS Nanterre sous le numéro 839 100 575, établissement de paiement et société de financement agréée par l’ACPR sous le n° 17408 (numéro CIB / Code banque)."
+              values={{
+                totalWithoutFirstInstallment: intl.formatNumber(totalWithoutFirstInstallment, {
+                  style: 'currency',
+                  currency: 'EUR',
+                }),
+                taegPercentage: intl.formatNumber(TAEG, {
+                  style: 'percent',
+                  maximumFractionDigits: 2,
+                }),
+                installmeentsCountWithoutFirst: currentPlan.installments_count - 1,
+                firstInstallmentAmount: intl.formatNumber(firstInstallmentAmount, {
+                  style: 'currency',
+                  currency: 'EUR',
+                }),
+                productPriceWithoutCreditCost: intl.formatNumber(total - creditCost, {
+                  style: 'currency',
+                  currency: 'EUR',
+                }),
+              }}
             />
           </div>
         )}

--- a/src/components/Installments/TotalBlock/index.tsx
+++ b/src/components/Installments/TotalBlock/index.tsx
@@ -82,9 +82,6 @@ const TotalBlock: FunctionComponent<{ currentPlan: EligibilityPlan }> = ({ curre
             </>
           )}
         </div>
-        {
-          // TODO: Add dynamic values according to the Figma
-        }
         {isCredit && (
           <div className={s.creditInfoLegalText}>
             <FormattedMessage

--- a/src/components/Installments/TotalBlock/index.tsx
+++ b/src/components/Installments/TotalBlock/index.tsx
@@ -14,6 +14,7 @@ const TotalBlock: FunctionComponent<{ currentPlan: EligibilityPlan }> = ({ curre
   const customerFees = priceFromCents(currentPlan.customer_total_cost_amount)
   const isCredit = currentPlan.installments_count > 4
   const firstInstallmentAmount = priceFromCents(currentPlan.payment_plan?.[0]?.total_amount ?? 0)
+  // For totalWithoutFirstInstallment, we need to get the total price and add the credit cost, before removing the first installment, to get the rest of the amount to pay.
   const totalWithoutFirstInstallment = priceFromCents(
     currentPlan.purchase_amount +
       currentPlan.customer_total_cost_amount -

--- a/src/intl/messages.json
+++ b/src/intl/messages.json
@@ -1,6 +1,7 @@
 {
   "credit-features.credit-cost-display": "{creditCost} (TAEG {taegPercentage})",
-  "credit-features.information": "Un crédit vous engage et doit être remboursé. Vérifiez vos capacités de remboursement avant de vous engager.",
+  "credit-features.information": "Vérifiez vos capacités de remboursement avant de vous engager.",
+  "credit-features.information.title": "Un crédit vous engage et doit être remboursé.",
   "credit-features.total-credit-cost": "Dont coût du crédit",
   "eligibility-modal.bullet-1": "Choisissez <strong>Alma</strong> au moment du paiement.",
   "eligibility-modal.bullet-2": "Laissez-vous guider et validez votre paiement en <strong>2 minutes.</strong>",
@@ -15,6 +16,7 @@
   "installments.today": "Aujourd'hui",
   "installments.total-amount": "Total",
   "installments.total-fees": "Dont frais (TTC)",
+  "payment-plan-strings.credit": "Cliquez pour en savoir plus",
   "payment-plan-strings.day-abbreviation": "J{deferredDays}",
   "payment-plan-strings.default-message": "Payez en plusieurs fois avec Alma",
   "payment-plan-strings.deferred": "{totalAmount} à payer le {dueDate}",

--- a/src/intl/messages/messages.de.json
+++ b/src/intl/messages/messages.de.json
@@ -1,6 +1,7 @@
 {
   "credit-features.credit-cost-display": "{creditCost} (APR {taegPercentage})",
-  "credit-features.information": "Ein Kredit verpflichtet Sie und muss zurückgezahlt werden. Prüfen Sie Ihre Rückzahlungsfähigkeit, bevor Sie sich verpflichten.",
+  "credit-features.information": "Überprüfen Sie Ihre Rückzahlungsmöglichkeiten, bevor Sie eine Verpflichtung eingehen.",
+  "credit-features.information.title": "Un crédit vous engage et doit être remboursé.",
   "credit-features.total-credit-cost": "Davon Kreditkosten",
   "eligibility-modal.bullet-1": "Wählen Sie <strong>Alma</strong> beim Check-out. ",
   "eligibility-modal.bullet-2": "Lassen Sie sich führen und bestätigen Sie Ihre Zahlung in <strong>2 Minuten.</strong>",
@@ -15,6 +16,7 @@
   "installments.today": "Heute",
   "installments.total-amount": "Gesamtsumme",
   "installments.total-fees": "Davon Kosten",
+  "payment-plan-strings.credit": "Klicken Sie, um mehr zu erfahren",
   "payment-plan-strings.day-abbreviation": "T{deferredDays}",
   "payment-plan-strings.default-message": "Bezahlen Sie zinsfrei in mehreren Raten mit Alma.",
   "payment-plan-strings.deferred": "{totalAmount} zu zahlen am {dueDate}",

--- a/src/intl/messages/messages.en.json
+++ b/src/intl/messages/messages.en.json
@@ -1,6 +1,7 @@
 {
   "credit-features.credit-cost-display": "{creditCost} (APR {taegPercentage})",
-  "credit-features.information": "A loan commits you and must be repaid. Check your ability to repay before committing yourself.",
+  "credit-features.information": "Vérifiez vos capacités de remboursement avant de vous engager.",
+  "credit-features.information.title": "Un crédit vous engage et doit être remboursé.",
   "credit-features.total-credit-cost": "Of which cost of credit",
   "eligibility-modal.bullet-1": "Choose <strong>Alma</strong> at checkout.",
   "eligibility-modal.bullet-2": "Let us guide you and validate your payment in <strong>2 minutes.</strong>",
@@ -15,6 +16,7 @@
   "installments.today": "Today",
   "installments.total-amount": "Total",
   "installments.total-fees": "Of which costs (incl. VAT)",
+  "payment-plan-strings.credit": "Cliquez pour en savoir plus",
   "payment-plan-strings.day-abbreviation": "D{deferredDays}",
   "payment-plan-strings.default-message": "Pay in installments with Alma",
   "payment-plan-strings.deferred": "{totalAmount} to pay the {dueDate}",

--- a/src/intl/messages/messages.es.json
+++ b/src/intl/messages/messages.es.json
@@ -1,6 +1,7 @@
 {
   "credit-features.credit-cost-display": "{creditCost} (TAE {taegPercentage})",
-  "credit-features.information": "Un préstamo te compromete y debe ser devuelto. Comprueba tu capacidad financiera antes de comprometerte.",
+  "credit-features.information": "Compruebe su capacidad de reembolso antes de comprometerse.",
+  "credit-features.information.title": "Un crédit vous engage et doit être remboursé.",
   "credit-features.total-credit-cost": "Coste de crédito (incl. en el total)",
   "eligibility-modal.bullet-1": "Elige <strong>Alma</strong> como método de pago.",
   "eligibility-modal.bullet-2": "Déjate guiar y válida tu pago en <strong>2 minutos.</strong>",
@@ -15,6 +16,7 @@
   "installments.today": "Hoy",
   "installments.total-amount": "Total",
   "installments.total-fees": "De los cuales, costes (IVA incluido)",
+  "payment-plan-strings.credit": "Más información",
   "payment-plan-strings.day-abbreviation": "D{deferredDays}",
   "payment-plan-strings.default-message": "Pagar a plazos con Alma",
   "payment-plan-strings.deferred": "{totalAmount} a pagar el {dueDate}",

--- a/src/intl/messages/messages.fr.json
+++ b/src/intl/messages/messages.fr.json
@@ -1,6 +1,7 @@
 {
   "credit-features.credit-cost-display": "{creditCost} (TAEG {taegPercentage})",
-  "credit-features.information": "Un crédit vous engage et doit être remboursé. Vérifiez vos capacités de remboursement avant de vous engager.",
+  "credit-features.information": "Vérifiez vos capacités de remboursement avant de vous engager.",
+  "credit-features.information.title": "Un crédit vous engage et doit être remboursé.",
   "credit-features.total-credit-cost": "Dont coût du crédit",
   "eligibility-modal.bullet-1": "Choisissez <strong>Alma</strong> au moment du paiement.",
   "eligibility-modal.bullet-2": "Laissez-vous guider et validez votre paiement en <strong>2 minutes.</strong>",
@@ -15,6 +16,7 @@
   "installments.today": "Aujourd'hui",
   "installments.total-amount": "Total",
   "installments.total-fees": "Dont frais (TTC)",
+  "payment-plan-strings.credit": "Cliquez pour en savoir plus",
   "payment-plan-strings.day-abbreviation": "J{deferredDays}",
   "payment-plan-strings.default-message": "Payez en plusieurs fois avec Alma",
   "payment-plan-strings.deferred": "{totalAmount} à payer le {dueDate}",

--- a/src/intl/messages/messages.it.json
+++ b/src/intl/messages/messages.it.json
@@ -1,6 +1,7 @@
 {
   "credit-features.credit-cost-display": "{creditCost} (TAEG {taegPercentage})",
-  "credit-features.information": "Un pagamento rateale ti impegna e deve essere ripagato. Verifica la tua disponibilità finanziaria prima di impegnarti.",
+  "credit-features.information": "Verificate la vostra capacità di rimborso prima di prendere un impegno.",
+  "credit-features.information.title": "Un crédit vous engage et doit être remboursé.",
   "credit-features.total-credit-cost": "Di cui commissioni",
   "eligibility-modal.bullet-1": "Seleziona <strong>Alma</strong> come metodo di pagamento.",
   "eligibility-modal.bullet-2": "Segui le istruzioni e completa l'acquisto <strong>in meno di 2 minuti.</strong>",
@@ -15,6 +16,7 @@
   "installments.today": "Oggi",
   "installments.total-amount": "Totale",
   "installments.total-fees": "Di cui commissioni",
+  "payment-plan-strings.credit": "Clicca qui per saperne di più",
   "payment-plan-strings.day-abbreviation": "G{deferredDays}",
   "payment-plan-strings.default-message": "Paga a rate con Alma, senza registrazione.",
   "payment-plan-strings.deferred": "{totalAmount} da pagare il {dueDate}",

--- a/src/intl/messages/messages.nl.json
+++ b/src/intl/messages/messages.nl.json
@@ -1,6 +1,7 @@
 {
   "credit-features.credit-cost-display": "{creditCost} (gemiddeld rente percentage {taegPercentage})",
-  "credit-features.information": "Een lening is bindend en moet worden terugbetaald. Ga na of je het kunt terugbetalen voordat je jezelf vastlegt.",
+  "credit-features.information": "Controleer je terugbetalingscapaciteit voordat je een toezegging doet.",
+  "credit-features.information.title": "Un crédit vous engage et doit être remboursé.",
   "credit-features.total-credit-cost": "Waarvan kredietkosten",
   "eligibility-modal.bullet-1": "Kies <strong>Alma</strong> bij het afrekenen om de eerste termijnbetaling te voldoen. Dit kan gemakkelijk via jouw favoriete betaalmethode.",
   "eligibility-modal.bullet-2": "Betaal gemakkelijk <strong>binnen 1 minuut </strong>. Je hebt hier geen account voor nodig.",
@@ -15,6 +16,7 @@
   "installments.today": "Vandaag",
   "installments.total-amount": "Totaal",
   "installments.total-fees": "Waarvan kosten (incl. BTW)",
+  "payment-plan-strings.credit": "Klik hier voor meer informatie",
   "payment-plan-strings.day-abbreviation": "D{deferredDays}",
   "payment-plan-strings.default-message": "Betaal in termijnen bij Alma - helemaal rentevrij",
   "payment-plan-strings.deferred": "{totalAmount} te betalen op {dueDate}",

--- a/src/intl/messages/messages.pt.json
+++ b/src/intl/messages/messages.pt.json
@@ -1,6 +1,7 @@
 {
   "credit-features.credit-cost-display": "{creditCost} (TAEG {taegPercentage})",
-  "credit-features.information": "Um crédito é um compromisso e deve ser reembolsado. Verifique a sua capacidade de pagar antes de se comprometer.",
+  "credit-features.information": "Verifique a sua capacidade de reembolso antes de assumir um compromisso.",
+  "credit-features.information.title": "Un crédit vous engage et doit être remboursé.",
   "credit-features.total-credit-cost": "Incluindo comissões de crédito",
   "eligibility-modal.bullet-1": "Seleccionar <strong>Alma - Pay Now</strong> no final da compra.",
   "eligibility-modal.bullet-2": "Siga as instruções e valide o seu pagamento em <strong>2 minutos.</strong>",
@@ -15,6 +16,7 @@
   "installments.today": "Hoje",
   "installments.total-amount": "Total",
   "installments.total-fees": "Das quais comissões (incl. IVA)",
+  "payment-plan-strings.credit": "Clique aqui para saber mais",
   "payment-plan-strings.day-abbreviation": "D{deferredDays}",
   "payment-plan-strings.default-message": "Pagamento em prestações com a Alma",
   "payment-plan-strings.deferred": "{totalAmount} a pagar em {dueDate}",

--- a/src/utils/paymentPlanStrings.module.css
+++ b/src/utils/paymentPlanStrings.module.css
@@ -1,0 +1,3 @@
+.openModalInfo {
+    text-decoration: underline;
+}

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -3,19 +3,19 @@ import React, { ReactNode } from 'react'
 import { FormattedDate, FormattedMessage, FormattedNumber } from 'react-intl'
 import { EligibilityPlan, EligibilityPlanToDisplay } from 'types'
 import { isP1X, priceFromCents } from 'utils'
+import s from './paymentPlanStrings.module.css'
 
 export const paymentPlanShorthandName = (payment: EligibilityPlan): ReactNode => {
   const { deferred_days, deferred_months, installments_count: installmentsCount } = payment
-  
+
   if (installmentsCount === 1 && !deferred_days && !deferred_months) {
     return (
       <FormattedMessage
         id="payment-plan-strings.pay.now.button"
         defaultMessage="Payer maintenant"
-        
       />
     )
-  } 
+  }
   if (installmentsCount === 1 && deferred_days) {
     return (
       <FormattedMessage
@@ -26,7 +26,7 @@ export const paymentPlanShorthandName = (payment: EligibilityPlan): ReactNode =>
         }}
       />
     )
-  } 
+  }
   if (installmentsCount === 1 && deferred_months) {
     return (
       <FormattedMessage
@@ -129,6 +129,18 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
       (installment, index) =>
         index === 0 || installment.total_amount === payment_plan[0].total_amount,
     )
+
+    if (installmentsCount > 4) {
+      return (
+        <span className={s.openModalInfo}>
+          <FormattedMessage
+            id="payment-plan-strings.credit"
+            defaultMessage="Cliquez pour en savoir plus"
+            description={`Link to credit details`}
+          />
+        </span>
+      )
+    }
 
     if (isP1X(payment)) {
       return (


### PR DESCRIPTION
We need to add legal text to the total block in the modal, and hide the price in the widget, if the user choses credit.

[See Figma](https://www.figma.com/design/IRkP8MSdJhRxg8NWi7wnEr/Widget_Credit?node-id=0-1&node-type=canvas&t=9MiWlkHc9hXqcfNT-0)

Fixes ECOM-2236