### PR TITLE
Attempt at fixing release-drafter workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,8 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_RELEASE_CHANGELOG_BOT_TOKEN }}
           payload: |
-            channel: CR9C57YM6 # alma_changelog 
-            text: ${{ steps.slack-markdown-release-notes.outputs.text }}
+            channel: CR9C57YM6 # alma_changelog
+            text: "${{ steps.slack-markdown-release-notes.outputs.text }}"
             username: "${{ github.event.sender.login }}"
             icon_url: "${{ github.event.sender.avatar_url }}"
 


### PR DESCRIPTION
Action payload changed with the slack action v2, but missing double-quotes might bring issues with the payload formatting.

Failing run: https://github.com/alma/widgets/actions/runs/12010376904/job/33477259179

> [!WARNING]
edit: this is a fix for the changelog publish, not release-drafter