### PR TITLE
Update readme and example files to use v4

### DIFF
--- a/.github/workflows/purge-js-delivr-cache.yml
+++ b/.github/workflows/purge-js-delivr-cache.yml
@@ -13,6 +13,7 @@ jobs:
           method: "POST"
           accept: 200,201,204,202
           headers: '{ "cache-control": "no-cache", "content-type": "application/json" }'
+          # TODO : Update with path for v4 files
           body: "{'path': ['/npm/@alma/widgets@3.x.x/dist/widgets.umd.js','/npm/@alma/widgets@3.x/dist/widgets.umd.js', '/npm/@alma/widgets@3.x.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@3.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@3.x.x/dist/widgets.module.css','/npm/@alma/widgets@3.x/dist/widgets.module.css','/npm/@alma/widgets@3.x.x/dist/widgets.css','/npm/@alma/widgets@3.x/dist/widgets.css','/npm/@alma/widgets@3.x.x/dist/widgets.min.css','/npm/@alma/widgets@3.x/dist/widgets.min.css']}"
 
           # If it is set to true, it will show the response log in the GitHub UI

--- a/README.md
+++ b/README.md
@@ -7,17 +7,16 @@ View all [Changelog](https://github.com/alma/widgets/releases)
 ## Setup
 
 ### Add the widget to your page
-TODO: remove => Changes to test precommit
 ##### CSS
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@alma/widgets@3.x/dist/widgets.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@alma/widgets@4.x/dist/widgets.min.css" />
 ```
 
 ##### JS
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@alma/widgets@3.x/dist/widgets.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@alma/widgets@4.x/dist/widgets.umd.js"></script>
 ```
 
 ### Create the container

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../dist/widgets.css" />
     <!-- <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@alma/widgets@3.x/dist/widgets.min.css"
+      href="https://cdn.jsdelivr.net/npm/@alma/widgets@4.x/dist/widgets.min.css"
     /> -->
   </head>
   <body>
@@ -49,7 +49,7 @@
       </div>
     </div>
     <script src="../dist/widgets.umd.js"></script>
-    <!-- <script src="https://cdn.jsdelivr.net/npm/@alma/widgets@3.x/dist/widgets.umd.js"></script> -->
+    <!-- <script src="https://cdn.jsdelivr.net/npm/@alma/widgets@4.x/dist/widgets.umd.js"></script> -->
 
     <script>
       var widgets = Alma.Widgets.initialize('11gKoO333vEXacMNMUMUSc4c4g68g2Les4', Alma.ApiMode.TEST)

--- a/examples/multiple.html
+++ b/examples/multiple.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../dist/widgets.umd.css" />
     <!-- <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@alma/widgets@3.x/dist/widgets.min.css"
+      href="https://cdn.jsdelivr.net/npm/@alma/widgets@4.x/dist/widgets.min.css"
     /> -->
   </head>
   <body>
@@ -53,7 +53,7 @@
       </div>
     </div>
     <script src="../dist/widgets.umd.js"></script>
-    <!-- <script src="https://cdn.jsdelivr.net/npm/@alma/widgets@3.x/dist/widgets.umd.js"></script> -->
+    <!-- <script src="https://cdn.jsdelivr.net/npm/@alma/widgets@4.x/dist/widgets.umd.js"></script> -->
 
     <script>
       var widgets = Alma.Widgets.initialize('11gKoO333vEXacMNMUMUSc4c4g68g2Les4', Alma.ApiMode.TEST)


### PR DESCRIPTION
Now that the v4 of the widget is release, we needed to update the readme accordingly as well as the example files.
This PR does not deal with the JSDelivr purge configuration at this point, we'll have to define which files of the v4 should be purged every time we release