### PR TITLE
fix(build): display correct user agent in header

### DIFF
--- a/src/hooks/useFetchEligibility.ts
+++ b/src/hooks/useFetchEligibility.ts
@@ -64,7 +64,7 @@ const useFetchEligibility = (
           },
           {
             Authorization: `Alma-Merchant-Auth ${merchantId}`,
-            'X-Alma-Agent': `Alma Widget/${process.env.VERSION}`,
+            'X-Alma-Agent': `Alma Widget/${process.env.BUILD_VERSION}`,
           },
           `${domain}/v2/payments/eligibility`,
         )

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_BUILD_VERSION: string
+  readonly BUILD_VERSION: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Fixes [MXP-2508](https://linear.app/almapay/issue/MXP-2508/bug-widget-version-is-not-defined-in-user-agent)

User agent was undefined because the environment variable was not names correctly

Run `BUILD_VERSION=local-test npm start` and open the widget. In the eligibility API call you should see the correct header

<img width="446" alt="Screenshot 2025-02-12 at 09 24 05" src="https://github.com/user-attachments/assets/1eb7ba9f-f77b-4992-bb2d-f4085f7a7677" />
