### PR TITLE
Fix cache for jsdelivr and eligibility

### DIFF
--- a/.github/workflows/purge-js-delivr-cache.yml
+++ b/.github/workflows/purge-js-delivr-cache.yml
@@ -13,8 +13,7 @@ jobs:
           method: "POST"
           accept: 200,201,204,202
           headers: '{ "cache-control": "no-cache", "content-type": "application/json" }'
-          # TODO : Update with path for v4 files
-          body: "{'path': ['/npm/@alma/widgets@3.x.x/dist/widgets.umd.js','/npm/@alma/widgets@3.x/dist/widgets.umd.js', '/npm/@alma/widgets@3.x.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@3.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@3.x.x/dist/widgets.module.css','/npm/@alma/widgets@3.x/dist/widgets.module.css','/npm/@alma/widgets@3.x.x/dist/widgets.css','/npm/@alma/widgets@3.x/dist/widgets.css','/npm/@alma/widgets@3.x.x/dist/widgets.min.css','/npm/@alma/widgets@3.x/dist/widgets.min.css']}"
+          body: "{'path': ['/npm/@alma/widgets@4.x/dist/widgets.js’,'/npm/@alma/widgets@4.x.x/dist/widgets.js’,‘/npm/@alma/widgets@4.x.x/dist/widgets.js.map’,‘/npm/@alma/widgets@4.x/dist/widgets.js.map’,'/npm/@alma/widgets@4.x.x/dist/widgets.umd.js','/npm/@alma/widgets@4.x/dist/widgets.umd.js', '/npm/@alma/widgets@4.x.x/dist/widgets.umd.js.map’,'/npm/@alma/widgets@4.x/dist/widgets.umd.js.map’, '/npm/@alma/widgets@4.x.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x.x/dist/widgets-wc.umd.js.map’,'/npm/@alma/widgets@4.x/dist/widgets-wc.umd.js.map’,'/npm/@alma/widgets@4.x.x/dist/widgets.css','/npm/@alma/widgets@4.x/dist/widgets.css','/npm/@alma/widgets@4.x.x/dist/widgets.min.css','/npm/@alma/widgets@4.x/dist/widgets.min.css']}"
 
           # If it is set to true, it will show the response log in the GitHub UI
           log-response: true

--- a/src/hooks/useSessionStorage.tsx
+++ b/src/hooks/useSessionStorage.tsx
@@ -50,8 +50,10 @@ export const useSessionStorage: () => UseSessionStorageType = () => {
 
     const stringAmount = purchaseAmount.toString()
     const stringPlans = JSON.stringify(plans)
+    // Using build version into the key to invalidate cache when the widget is updated
+    const buildVersion = process.env.BUILD_VERSION ?? 'local-build'
     return hashStringForStorage(
-      `${stringAmount}${stringPlans}${customerBillingCountry}${customerShippingCountry}`,
+      `${stringAmount}${stringPlans}${customerBillingCountry}${customerShippingCountry}${buildVersion}`,
     )
   }
 


### PR DESCRIPTION
This PR : 
- Adds the widget version in the hash created to store eligibility response in session storage. That way, if the widget is updated, the cache is cleared.
- Updates the file name to be un-cached from JSDelivr when publishing a new version of the widget so the files from v4 are up to date.