### PR TITLE
Remove map files from list to purge jsdelivr cache & fix quote typo

### DIFF
--- a/.github/workflows/purge-js-delivr-cache.yml
+++ b/.github/workflows/purge-js-delivr-cache.yml
@@ -13,7 +13,7 @@ jobs:
           method: "POST"
           accept: 200,201,204,202
           headers: '{ "cache-control": "no-cache", "content-type": "application/json" }'
-          body: "{'path': ['/npm/@alma/widgets@4.x/dist/widgets.js’,'/npm/@alma/widgets@4.x.x/dist/widgets.js’,'/npm/@alma/widgets@4.x.x/dist/widgets.umd.js','/npm/@alma/widgets@4.x/dist/widgets.umd.js', '/npm/@alma/widgets@4.x.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x.x/dist/widgets.css','/npm/@alma/widgets@4.x/dist/widgets.css','/npm/@alma/widgets@4.x.x/dist/widgets.min.css','/npm/@alma/widgets@4.x/dist/widgets.min.css']}"
+          body: "{'path': ['/npm/@alma/widgets@4.x/dist/widgets.js','/npm/@alma/widgets@4.x.x/dist/widgets.js','/npm/@alma/widgets@4.x.x/dist/widgets.umd.js','/npm/@alma/widgets@4.x/dist/widgets.umd.js', '/npm/@alma/widgets@4.x.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x.x/dist/widgets.css','/npm/@alma/widgets@4.x/dist/widgets.css','/npm/@alma/widgets@4.x.x/dist/widgets.min.css','/npm/@alma/widgets@4.x/dist/widgets.min.css']}"
 
           # If it is set to true, it will show the response log in the GitHub UI
           log-response: true

--- a/.github/workflows/purge-js-delivr-cache.yml
+++ b/.github/workflows/purge-js-delivr-cache.yml
@@ -13,7 +13,7 @@ jobs:
           method: "POST"
           accept: 200,201,204,202
           headers: '{ "cache-control": "no-cache", "content-type": "application/json" }'
-          body: "{'path': ['/npm/@alma/widgets@4.x/dist/widgets.js’,'/npm/@alma/widgets@4.x.x/dist/widgets.js’,‘/npm/@alma/widgets@4.x.x/dist/widgets.js.map’,‘/npm/@alma/widgets@4.x/dist/widgets.js.map’,'/npm/@alma/widgets@4.x.x/dist/widgets.umd.js','/npm/@alma/widgets@4.x/dist/widgets.umd.js', '/npm/@alma/widgets@4.x.x/dist/widgets.umd.js.map’,'/npm/@alma/widgets@4.x/dist/widgets.umd.js.map’, '/npm/@alma/widgets@4.x.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x.x/dist/widgets-wc.umd.js.map’,'/npm/@alma/widgets@4.x/dist/widgets-wc.umd.js.map’,'/npm/@alma/widgets@4.x.x/dist/widgets.css','/npm/@alma/widgets@4.x/dist/widgets.css','/npm/@alma/widgets@4.x.x/dist/widgets.min.css','/npm/@alma/widgets@4.x/dist/widgets.min.css']}"
+          body: "{'path': ['/npm/@alma/widgets@4.x/dist/widgets.js’,'/npm/@alma/widgets@4.x.x/dist/widgets.js’,'/npm/@alma/widgets@4.x.x/dist/widgets.umd.js','/npm/@alma/widgets@4.x/dist/widgets.umd.js', '/npm/@alma/widgets@4.x.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x/dist/widgets-wc.umd.js','/npm/@alma/widgets@4.x.x/dist/widgets.css','/npm/@alma/widgets@4.x/dist/widgets.css','/npm/@alma/widgets@4.x.x/dist/widgets.min.css','/npm/@alma/widgets@4.x/dist/widgets.min.css']}"
 
           # If it is set to true, it will show the response log in the GitHub UI
           log-response: true


### PR DESCRIPTION
Not sure why it fails https://github.com/alma/widgets/actions/runs/13287484591/job/37101518107#step:2:13

Files list can be found here : https://www.jsdelivr.com/package/npm/@alma/widgets?tab=files&path=dist

The map files were not purged with the v3, trying to remove them from the v4 purge to see if it is part of the issue.

Also, changed a fake quote `’` into `'` 