### PR TITLE
Fix/cache for eligibility

### DIFF
--- a/src/hooks/useFetchEligibility.ts
+++ b/src/hooks/useFetchEligibility.ts
@@ -17,12 +17,14 @@ const useFetchEligibility = (
   const [status, setStatus] = useState(statusResponse.PENDING)
 
   // caching
-  const { getCache, setCache, createKey } = useSessionStorage()
+  const { getCache, setCache, createKey, clearCache } = useSessionStorage()
   const key = createKey({
     purchaseAmount,
     plans,
     customerBillingCountry,
     customerShippingCountry,
+    domain,
+    merchantId,
   })
   const currentCache = getCache(key)?.value
   const lastCacheTimestamp = getCache(key)?.timestamp
@@ -53,8 +55,12 @@ const useFetchEligibility = (
         setEligibility(currentCache)
         setStatus(statusResponse.SUCCESS)
       }
-
-      if (!currentCache || shouldInvalidate) {
+      if (shouldInvalidate) {
+        // If we should invalidate, we clear all cache
+        clearCache()
+      }
+      if (!currentCache) {
+        // Fetch eligibility from API
         fetchFromApi(
           {
             purchase_amount: purchaseAmount,

--- a/src/hooks/useFetchEligibility.ts
+++ b/src/hooks/useFetchEligibility.ts
@@ -69,9 +69,14 @@ const useFetchEligibility = (
           `${domain}/v2/payments/eligibility`,
         )
           .then((res) => {
-            setCache(key, res)
-            setEligibility(res)
-            setStatus(statusResponse.SUCCESS)
+            // If the response contains an error_code, we set the status to failed - for example if code is 403 unauthorized
+            if ('error_code' in res) {
+              setStatus(statusResponse.FAILED)
+            } else {
+              setEligibility(res as EligibilityPlan[])
+              setCache(key, res as EligibilityPlan[])
+              setStatus(statusResponse.SUCCESS)
+            }
           })
           .catch(() => {
             setStatus(statusResponse.FAILED)
@@ -91,7 +96,6 @@ const useFetchEligibility = (
     domain,
     setCache,
   ])
-
   return [filterEligibility(eligibility, plans), status]
 }
 export default useFetchEligibility

--- a/src/hooks/useFetchEligibility.ts
+++ b/src/hooks/useFetchEligibility.ts
@@ -101,6 +101,7 @@ const useFetchEligibility = (
     merchantId,
     domain,
     setCache,
+    clearCache,
   ])
   return [filterEligibility(eligibility, plans), status]
 }

--- a/src/hooks/useSessionStorage.tsx
+++ b/src/hooks/useSessionStorage.tsx
@@ -6,6 +6,8 @@ type CreateKeyType = {
   plans?: ConfigPlan[]
   customerBillingCountry?: string
   customerShippingCountry?: string
+  domain?: string
+  merchantId?: string
 }
 
 type StorageType = {
@@ -46,14 +48,21 @@ export const useSessionStorage: () => UseSessionStorageType = () => {
   }
 
   const createKey = (params: CreateKeyType): string => {
-    const { purchaseAmount, plans, customerBillingCountry, customerShippingCountry } = params
+    const {
+      purchaseAmount,
+      plans,
+      customerBillingCountry,
+      customerShippingCountry,
+      domain,
+      merchantId,
+    } = params
 
     const stringAmount = purchaseAmount.toString()
     const stringPlans = JSON.stringify(plans)
     // Using build version into the key to invalidate cache when the widget is updated
     const buildVersion = process.env.BUILD_VERSION ?? 'local-build'
     return hashStringForStorage(
-      `${stringAmount}${stringPlans}${customerBillingCountry}${customerShippingCountry}${buildVersion}`,
+      `${domain}${merchantId}${stringAmount}${stringPlans}${customerBillingCountry}${customerShippingCountry}${buildVersion}`,
     )
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,11 @@ export type EligibilityPlan = {
   }
 }
 
+export type ErrorResponse = {
+  message?: string
+  error_code?: string
+}
+
 export type EligibilityPlanToDisplay = EligibilityPlan & {
   minAmount?: number
   maxAmount?: number

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,10 +1,10 @@
-import { EligibilityPlan } from '@/types'
+import { EligibilityPlan, ErrorResponse } from '@/types'
 
 export async function fetchFromApi(
   data: { [key: string]: unknown },
   headers?: { [key: string]: unknown },
   url = '',
-): Promise<EligibilityPlan[]> {
+): Promise<EligibilityPlan[] | ErrorResponse> {
   const response = await fetch(url, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Fixes MXP-2595

Issues with sessionStorage cache from the eligibility calls.

- Added merchantId & domain in the key-hash for cached responses => If the merchant changes their configuration, then a call will be made again instead of using the old configuration response
- Added a condition not to store data from an error response such as "unauthorized"