### PR TITLE
Returns error in case api response contains 'errors' key

### DIFF
--- a/src/hooks/useFetchEligibility.ts
+++ b/src/hooks/useFetchEligibility.ts
@@ -76,7 +76,9 @@ const useFetchEligibility = (
         )
           .then((res) => {
             // If the response contains an error_code, we set the status to failed - for example if code is 403 unauthorized
-            if ('error_code' in res) {
+            // When purchase amount & plans are not compatible, the API returns an error {"running": {"message": "'purchase_amount'"}} which does not contain the key `error_code`
+            // And the widget keeps loading if we don't handle it, so we need to cover this case and returns a FAILED status
+            if ('error_code' in res || 'errors' in res) {
               setStatus(statusResponse.FAILED)
             } else {
               setEligibility(res as EligibilityPlan[])


### PR DESCRIPTION
Widget is based on `POST v2/payments/eligibility` response to define its behavior.
Most of the time, eligibility response in case of error is constructed with a property `error_code`.
In the widget code, we explicitly covered this case with
```
  if ('error_code' in res) {
       setStatus(statusResponse.FAILED)
  } else {
  ...
```

But there is a specific scenario in which the API respond with a error that does not contains `error_code`, so
it was not correctly catched in the widgets's code, and so the widget was blocked in "PENDING" state 
<img width="484" height="346" alt="Capture d’écran 2025-07-31 à 10 54 11" src="https://github.com/user-attachments/assets/62c90297-7aa9-4893-be8c-5417a19bf8ea" />

This behavior can be reproduced locally by configuring the widget this way in `basic.html` (from the master branch) : 
```
function renderPaymentPlans() {
  var purchaseAmount = 0
  widgets.add(Alma.Widgets.PaymentPlans, {
    container: '#alma-widget-payment-plans',
    locale: 'fr',
    purchaseAmount,
    plans: [{
      installmentsCount: 1,
      deferredDays: 0,
      deferredMonths: 0
    }, {
      installmentsCount: 2,
      deferredDays: 0,
      deferredMonths: 0
    }]
  })
}
```

Which corresponds to calling `POST v2/payments/eligibility` with the payload : 
```
{
    "purchase_amount": 0,
    "queries": [
        {
            "installments_count": 1,
            "deferred_days": 0,
            "deferred_months": 0
        },
        {
            "installments_count": 2,
            "deferred_days": 0,
            "deferred_months": 0
        }
    ],
    "billing_address": null,
    "shipping_address": null
}
```

Then, you'll notice the API response is : 
```
{
    "errors": {
        "running": {
            "message": "'purchase_amount'"
        }
    }
}
```

Now, this PR fixes this behavior by adding a condition to the previous one : 
```
if ('error_code' in res || 'errors' in res) {
  setStatus(statusResponse.FAILED)
   } else {
   ....
```
And now, the widget is correctly hidden because of the eligibility error 
<img width="500" height="265" alt="Capture d’écran 2025-07-31 à 10 59 02" src="https://github.com/user-attachments/assets/7f90d8da-3591-4bb9-b8ce-7fa4c7164874" />
