### PR TITLE
chore/rgaa fix focus indicators

### DIFF
--- a/examples/multiple.html
+++ b/examples/multiple.html
@@ -6,7 +6,7 @@
     <title>Alma Widgets multiple configuration example</title>
 
     <link rel="stylesheet" href="./style.css" />
-    <link rel="stylesheet" href="../dist/widgets.umd.css" />
+    <link rel="stylesheet" href="../dist/widgets.css" />
     <!-- <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@alma/widgets@4.x/dist/widgets.min.css"

--- a/src/Widgets/PaymentPlans/PaymentPlans.module.css
+++ b/src/Widgets/PaymentPlans/PaymentPlans.module.css
@@ -12,7 +12,12 @@
 
 .widgetButton:focus,
 .widgetButton:focus-visible {
-  outline: none;
+  outline: 1px solid var(--alma-orange);
+}
+
+.widgetButton.monochrome:focus,
+.widgetButton.monochrome:focus-visible {
+  outline: 1px solid black;
 }
 
 .logo {

--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -147,6 +147,7 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
             [s.clickable]: eligiblePlans.length > 0,
             [s.unClickable]: eligiblePlans.length === 0,
             [s.hideBorder]: hideBorder,
+            [s.monochrome]: monochrome,
           },
           STATIC_CUSTOMISATION_CLASSES.container,
         )}

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -9,7 +9,10 @@
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
   padding-top: 48px;
-  outline: none;
+}
+.modal:focus,
+.modal:focus-visible {
+  outline: 1px solid var(--alma-orange);
 }
 
 .content {


### PR DESCRIPTION
Fixes MXP-3259

Remove the `outline: none;` css property on focusable items,
Replace it with visible outline based on the monochrome property to respect the UI Theme of the widget.

Before : 
![before focus outline](https://github.com/user-attachments/assets/8af779fc-f99a-4327-a37a-25934ef412cc)

After: 
![after outline focus](https://github.com/user-attachments/assets/b807d032-3a8f-4661-9786-f1fbdfa8d8e8)
