### PR TITLE
Lock button style to avoid merchant override

### DIFF
--- a/src/Widgets/PaymentPlans/PaymentPlans.module.css
+++ b/src/Widgets/PaymentPlans/PaymentPlans.module.css
@@ -153,23 +153,35 @@
   cursor: not-allowed;
 }
 
+/*
+ * Reset button styles to prevent merchant site CSS overrides.
+ * Uses !important to ensure widget display integrity when merchants
+ * have global button styles that could interfere.
+ */
 .knowMore {
-  display: flex;
+  all: unset;
+  display: flex !important;
   gap: 6px;
   align-items: center;
-  background-color: transparent;
-  border: none;
+  background-color: transparent !important;
+  border: none !important;
   text-decoration: underline;
-  margin-right: 12px;
+  margin: 0 12px 0 0 !important;
+  padding: 3px !important;
+  font-family: inherit !important;
+  font-size: inherit !important;
+  color: inherit !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
 }
 
 .knowMore:focus,
 .knowMore:focus-visible {
-  border-radius: 4px;
-  outline: 1px solid var(--alma-orange);
+  border-radius: 4px !important;
+  outline: 1px solid var(--alma-orange) !important;
 }
 
 .knowMore.monochrome:focus,
 .knowMore.monochrome:focus-visible {
-  outline: 1px solid black;
+  outline: 1px solid black !important;
 }


### PR DESCRIPTION
Shoudl Fix https://almapay.slack.com/archives/C02EKEPCZN1/p1757074653944999 and https://almapay.slack.com/archives/CP1SUFY3U/p1757066510457869

Now that the Alma Logo is wrapped into a tag `button`, some website that includes the widget can have css files that impacts `button` in general, which could break our widget design.