### PR TITLE
Use px instead of rem to avoid css impact

### DIFF
--- a/examples/style.css
+++ b/examples/style.css
@@ -1,3 +1,8 @@
+html {
+  /* Simulating impact on font size ... */
+  font-size: 62.5%;
+}
+
 body {
   font-family: Helvetica, Arial, 'Segoe UI', sans-serif;
   background-color: #edf6fd;
@@ -80,7 +85,7 @@ body {
 .open-modal-ctas a:visited {
   display: block;
   margin: 8px 0;
-  font-size: 14px;
+  font-size: var(--font-small);
   color: #00425d;
 }
 

--- a/src/Widgets/EligibilityModal/EligibilityModal.module.css
+++ b/src/Widgets/EligibilityModal/EligibilityModal.module.css
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   text-align: center;
-  font-size: 1.25rem; /* 20px */
+  font-size: var(--font-medium);
 }
 
 .loader {

--- a/src/Widgets/EligibilityModal/components/EligibilityPlansButtons/EligibilityPlansButtons.module.css
+++ b/src/Widgets/EligibilityModal/components/EligibilityPlansButtons/EligibilityPlansButtons.module.css
@@ -17,7 +17,7 @@
     border: 1px solid var(--dark-gray);
     border-radius: 16px;
     font-family: 'Argent', sans-serif;
-    font-size: 1.25rem; /* 20px */
+    font-size: var(--font-medium);
     line-height: 120%;
     font-weight: 600;
     cursor: pointer;
@@ -35,7 +35,7 @@
   border: 1px solid var(--dark-gray);
   border-radius: 16px;
   font-family: 'Argent', sans-serif;
-  font-size: 1.25rem; /* 20px */
+  font-size: var(--font-medium);
   line-height: 120%;
   font-weight: 600;
   cursor: pointer;

--- a/src/Widgets/EligibilityModal/components/Info/Info.module.css
+++ b/src/Widgets/EligibilityModal/components/Info/Info.module.css
@@ -18,12 +18,13 @@
   align-items: center;
   line-height: 135%;
   gap: 16px;
+  font-size: var(--font-small);
 }
 
 .bullet {
   font-family: 'Argent', sans-serif;
   font-weight: 600;
-  font-size: 2rem; /* 32px */
+  font-size: var(--font-x-large);
   min-width: 20px;
   line-height: 110%;
   color: var(--alma-blue);

--- a/src/Widgets/EligibilityModal/components/Title/Title.module.css
+++ b/src/Widgets/EligibilityModal/components/Title/Title.module.css
@@ -1,7 +1,7 @@
 .title {
   font-family: 'Argent', sans-serif;
   font-weight: 600;
-  font-size: 1.25rem; /* 20px */
+  font-size: var(--font-medium);
   line-height: 130%;
   text-align: center;
   margin: 0 0 24px 0;
@@ -9,6 +9,6 @@
 
 @media (min-width: 800px) {
   .title {
-    font-size: 1.5rem; /* 24px */
+    font-size: var(--font-large);
   }
 }

--- a/src/Widgets/PaymentPlans/PaymentPlans.module.css
+++ b/src/Widgets/PaymentPlans/PaymentPlans.module.css
@@ -30,7 +30,7 @@
   color: var(--off-black);
   border-radius: 4px;
   font-weight: 700;
-  font-size: 0.75rem; /* Equivalent to 12px but adapts to zoom */
+  font-size: var(--font-x-small);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -113,7 +113,7 @@
 }
 
 .info {
-  font-size: 0.75rem; /* 12px */
+  font-size: var(--font-x-small);
   line-height: 16px;
   color: var(--dark-gray);
   text-align: center;

--- a/src/components/Installments/TotalBlock/TotalBlock.module.css
+++ b/src/components/Installments/TotalBlock/TotalBlock.module.css
@@ -19,7 +19,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  font-size: 1.25rem; /* 20px */
+  font-size: var(--font-medium);
 }
 
 .creditInfo {
@@ -30,7 +30,7 @@
   padding: 16px;
   z-index: 2;
   position: relative;
-  font-size: 1rem; /* 16px */
+  font-size: var(--font-base);
 }
 
 .creditInfoTitle {
@@ -43,7 +43,7 @@
   flex-direction: row;
   justify-content: space-between;
   font-weight: var(--weight-bold);
-  font-size: 0.875rem; /* 14px */
+  font-size: var(--font-small);
   line-height: 135%;
 }
 
@@ -52,7 +52,7 @@
 }
 
 .creditInfoLegalText {
-  font-size: 0.625rem; /* 10px */
+  font-size: var(--font-tiny);
   font-family: 'Venn', sans-serif;
   margin-top: 8px;
   font-weight: var(--weight-normal);

--- a/src/components/SkipLinks/SkipLinks.module.css
+++ b/src/components/SkipLinks/SkipLinks.module.css
@@ -37,7 +37,7 @@
     color: #fff;
     text-decoration: none;
     border-radius: 4px;
-    font-size: 0.875rem; /* Equivalent to 14px but adapts to zoom */
+    font-size: var(--font-small);
     font-weight: 600;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
     outline: 1px solid var(--alma-orange);

--- a/src/main.css
+++ b/src/main.css
@@ -23,7 +23,15 @@
   --black: #000;
 
   /** Font **/
-  --font-base: 1rem; /* 16px */
+
+  /* Some merchants override font size which impacts rem - using px instead even if not recommended for accessibility */
+  --font-tiny: 10px;
+  --font-x-small: 12px;
+  --font-small: 14px;
+  --font-base: 16px;
+  --font-medium: 20px;
+  --font-large: 24px;
+  --font-x-large: 32px;
 }
 
 /** Venn **/


### PR DESCRIPTION
We introduced font-size in rem to match accessibility rules, but it seems that with some merchant's theme and styling, it has an impact. Keeping `px` to ensure the widget is displayed as it's supposed to.