### PR TITLE
[EligibilityModal] Wrong `verticalLine` positioning on screens < 800px

### DIFF
--- a/src/Widgets/EligibilityModal/EligibilityModal.module.css
+++ b/src/Widgets/EligibilityModal/EligibilityModal.module.css
@@ -19,8 +19,8 @@
 
 .verticalLine {
   position: absolute;
-  top: 15px;
-  left: 5px;
+  top: 20px;
+  left: 11px;
   width: 2px;
 
   /* 120px is a magic number, to avoid seeing the line under the TotalBlock */


### PR DESCRIPTION
## 🔍 Context
Fixes #207 
## 🏗 Work
- [x] Simple absolute positioning tweaking
## 💡 Result
|Before|After|
|-|-|
|<img width="386" height="696" alt="Capture d’écran 2025-12-12 à 09 39 25" src="https://github.com/user-attachments/assets/0899078d-5b60-469f-8932-892e587e7a29" />|<img width="386" height="696" alt="Capture d’écran 2025-12-12 à 09 39 12" src="https://github.com/user-attachments/assets/3c3b3e0c-a41c-4739-85ab-b95a322075ad" />|

## 🗒 Notes