### PR TITLE
ci(release): review release workflow with new npm authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,33 +3,43 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types:
+      - published
 
 jobs:
   publish-package:
     name: Publish package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read  # checkout repository
+      id-token: write  # npm authentication
+
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Use Node.js 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 22
+          node-version-file: .nvmrc
+
       - run: npm ci
         # We do not create a commit with the update package version
         # Therefore the package.*.json in the repository will always have out-of-sync versions
+
       - name: Set version in code (update package.json)
         run: npm --no-git-tag-version version ${{ github.event.release.tag_name }}
+
       - name: Build library
         run: npm run build
         env:
           BUILD_VERSION: ${{ github.event.release.tag_name }}
+
       - name: Publish library
         run: npm run publish
-        env:
-          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish build assets to release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: |
             ./dist/widgets.umd.js
@@ -38,8 +48,6 @@ jobs:
             ./dist/widgets.js
             ./dist/widgets.css
             ./dist/widgets-wc.umd.js
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Send changelog to Slack
   slack-notification:
@@ -47,10 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          # Fetch the latest commit, only
-          fetch-depth: 1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Get release notes
         id: release-notes
@@ -85,7 +90,7 @@ jobs:
             ${{ steps.release-notes.outputs.RELEASE_NOTES }}
 
       - name: Send changelog to Slack
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_RELEASE_CHANGELOG_BOT_TOKEN }}
@@ -94,4 +99,3 @@ jobs:
             text: ${{ toJson(steps.slack-markdown-release-notes.outputs.text) }}
             username: "${{ github.event.sender.login }}"
             icon_url: "${{ github.event.sender.avatar_url }}"
-


### PR DESCRIPTION
Classic token authentication for NPM has been discontinued and [OIDC authentication](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/) must now be used.

---

closes [ALF-889](https://linear.app/almapay/issue/ALF-889/it-seems-that-the-last-two-releases-of-the-widget-havent-been-applied)