### PR TITLE
renovate(config): fix configuration format

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
   "enabledManagers": [ "github-actions", "nvm", "npm" ],
   "reviewers": [ "team:squad-e-commerce-integrations" ],
   "separateMinorPatch": true,
+  "separateMultipleMajor": true,
   "packageRules": [
     {
       "matchManagers": [ "npm" ],
@@ -15,7 +16,6 @@
       "matchManagers": [ "npm" ],
       "matchUpdateTypes": [ "major" ],
       "dependencyDashboardApproval": true,
-      "separateMultipleMajor": true,
     }
   ]
 }


### PR DESCRIPTION
Fix Renovate configuration that has been failing for a while.

```bash
$ npx --package renovate -- renovate-config-validator .github/renovate.json
 INFO: Validating .github/renovate.json5 as global config
 INFO: Config validated successfully
```