### PR TITLE
ci(release): publish through npm directly, use clean-publish as initial step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     permissions:
-      contents: read  # checkout repository
+      contents: write  # checkout repository, write release assets
       id-token: write  # npm authentication
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,10 @@ jobs:
           BUILD_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Publish library
-        run: npm run publish
+        run: |
+          npx clean-publish
+          cd clean-package/
+          npm publish --provenance
 
       - name: Publish build assets to release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs
 stats.html
 dist/
 raw/
+clean-package/

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "translations:extract": "formatjs extract 'src/**/*.ts*' --out-file 'src/intl/messages.json' --format simple --ignore 'src/*.d.ts' && prettier ./src/intl --write",
     "translations:upload": "crowdin upload sources",
     "translations:download": "crowdin download && prettier ./src/intl --write",
-    "publish": "clean-publish",
     "prepare": "husky"
   },
   "devDependencies": {
@@ -123,5 +122,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "clean-publish": {
+    "withoutPublish": true,
+    "tempDir": "clean-package"
   }
 }


### PR DESCRIPTION
It seems like `clean-publish` does not work well with OIDC authentication because it uses a temporary dir. This may fix it by generating the clean package folder and then publishing from it.