### PR TITLE
ci(release): add registry-url to setup-node action to try and fix OIDC authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
         # We do not create a commit with the update package version

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}


### PR DESCRIPTION
We may need the registry-url in setup-node if we want to follow the docs exactly.