### PR TITLE
chore(font): update argent cf url

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -61,12 +61,13 @@
 @font-face {
   font-family: Argent;
   src:
-    url('https://cdn.almapay.com/fonts/Argent/ArgentCF-DemiBold.eot') format('embedded-opentype'),
-    url('https://cdn.almapay.com/fonts/Argent/ArgentCF-DemiBold.woff') format('woff'),
-    url('https://cdn.almapay.com/fonts/Argent/ArgentCF-DemiBold.ttf') format('truetype');
+    url("https://use.typekit.net/af/ba7126/00000000000000007735f8a4/31/l?subset_id=2&fvd=n6&v=3") format("woff2"),
+    url("https://use.typekit.net/af/ba7126/00000000000000007735f8a4/31/d?subset_id=2&fvd=n6&v=3") format("woff"),
+    url("https://use.typekit.net/af/ba7126/00000000000000007735f8a4/31/a?subset_id=2&fvd=n6&v=3") format("opentype");
   font-weight: 600;
   font-style: normal;
   font-display: swap;
+  font-stretch: normal;
 }
 
 /**


### PR DESCRIPTION
This pull request updates the `@font-face` definition for the `Argent` font in the main stylesheet to use new font file sources from Typekit, replacing the previous CDN URLs. 