### PR TITLE
Fix release-drafter config schema

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,7 +14,8 @@ categories:
     labels:
       - 'type: bugfix'
   - title: '📝 Documentation'
-    labels: 'type: docs'
+    labels:
+      - 'type: docs'
   - title: '🔐 Security'
     labels:
       - 'type: security'


### PR DESCRIPTION
To prepare for the merge of https://github.com/alma/widgets/pull/237, we must fix our release-drafter configuration to comply to new enforcing rules