### PR TITLE
Automatically hide ineligible plans with no price-range context

### DIFF
--- a/examples/multiple.html
+++ b/examples/multiple.html
@@ -40,6 +40,12 @@
             <p>Polychrome widget</p>
 
             <div id="alma-widget-payment-plans2"></div>
+            <h3>450 €</h3>
+            <p>Widget with ineligible plans hidden automatically (non-price-range reasons)</p>
+            <div id="alma-widget-payment-plans3"></div>
+            <h3>450 €</h3>
+            <p>Widget with p4x grayed out (purchase amount out of range)</p>
+            <div id="alma-widget-payment-plans4"></div>
             <div id="alma-widget-modal"></div>
             <div class="add-to-cart">
               <button>Ajouter au panier</button>
@@ -106,6 +112,27 @@
           monochrome: false,
           cards: ['visa'],
           suggestedPaymentPlan: [2],
+        })
+        renderPaymentPlans(450 * 100, '#alma-widget-payment-plans3', {})
+        renderPaymentPlans(450 * 100, '#alma-widget-payment-plans4', {
+          plans: [
+            {
+              installmentsCount: 2,
+              minAmount: 5000,
+              maxAmount: 90000,
+            },
+            {
+              installmentsCount: 3,
+              minAmount: 5000,
+              maxAmount: 90000,
+            },
+            {
+              installmentsCount: 4,
+              minAmount: 5000,
+              maxAmount: 20000, // 450€ is above this → p4x grayed out with "Jusqu'à 200€"
+            },
+          ],
+          suggestedPaymentPlan: [3],
         })
       }
       generateRenderer()

--- a/src/Widgets/PaymentPlans/__tests__/HideIneligiblePlans.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/HideIneligiblePlans.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+
+import { screen } from '@testing-library/react'
+
+import { ApiMode } from '@/consts'
+import render from '@/test'
+import {
+  mockEligibilityPaymentPlanWithIneligiblePlan,
+  mockEligibilityWithGrayedOutPlan,
+  mockEligibilityWithHiddenPlan,
+} from 'test/fixtures'
+import PaymentPlanWidget from 'Widgets/PaymentPlans'
+
+let fetchResult: unknown = mockEligibilityPaymentPlanWithIneligiblePlan
+
+jest.mock('utils/fetch', () => ({
+  fetchFromApi: () => Promise.resolve(fetchResult),
+}))
+
+const configPlans = [
+  {
+    installmentsCount: 1,
+    deferredDays: 30,
+    minAmount: 5000,
+    maxAmount: 70000,
+  },
+  {
+    installmentsCount: 2,
+    minAmount: 5000,
+    maxAmount: 50000,
+  },
+  {
+    installmentsCount: 4,
+    minAmount: 5000,
+    maxAmount: 15000,
+  },
+]
+
+const apiData = { domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }
+
+beforeAll(() => {
+  jest.useFakeTimers().setSystemTime(new Date('2020-01-01').getTime())
+})
+
+afterAll(() => {
+  jest.useRealTimers()
+})
+
+describe('Ineligible plan due to purchase_amount range stays grayed out', () => {
+  beforeEach(() => {
+    fetchResult = mockEligibilityPaymentPlanWithIneligiblePlan
+  })
+
+  it('keeps grayed-out the plan ineligible due to price range', async () => {
+    render(<PaymentPlanWidget purchaseAmount={45000} configPlans={configPlans} apiData={apiData} />)
+    await screen.findByTestId('widget-container')
+
+    expect(screen.getByText('J+30')).toBeInTheDocument()
+    expect(screen.getByText('2x')).toBeInTheDocument()
+    // 4x is ineligible due to purchase_amount range → still shown grayed out
+    expect(screen.getByText('4x')).toBeInTheDocument()
+  })
+
+  it('keeps grayed-out the plan with explicit constraints.purchase_amount', async () => {
+    fetchResult = mockEligibilityWithGrayedOutPlan
+    render(<PaymentPlanWidget purchaseAmount={45000} configPlans={configPlans} apiData={apiData} />)
+    await screen.findByTestId('widget-container')
+
+    expect(screen.getByText('J+30')).toBeInTheDocument()
+    expect(screen.getByText('2x')).toBeInTheDocument()
+    // 4x has constraints.purchase_amount → grayed out, not hidden
+    expect(screen.getByText('4x')).toBeInTheDocument()
+  })
+})
+
+describe('Ineligible plan due to non-purchase_amount reason is hidden', () => {
+  beforeEach(() => {
+    fetchResult = mockEligibilityWithHiddenPlan
+  })
+
+  it('hides the plan ineligible due to installments_count reason', async () => {
+    render(<PaymentPlanWidget purchaseAmount={45000} configPlans={configPlans} apiData={apiData} />)
+    await screen.findByTestId('widget-container')
+
+    expect(screen.getByText('J+30')).toBeInTheDocument()
+    expect(screen.getByText('2x')).toBeInTheDocument()
+    // 4x is ineligible due to installments_count → hidden entirely
+    expect(screen.queryByText('4x')).not.toBeInTheDocument()
+  })
+})

--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -80,9 +80,16 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
     [eligibilityPlans],
   )
 
+  // Plans to render: automatically hide plans marked as hidden in filterEligibility
+  // (i.e. ineligible for a reason other than purchase_amount range)
+  const plansToDisplay = useMemo(
+    () => eligibilityPlans.filter((plan) => !plan.hidden),
+    [eligibilityPlans],
+  )
+
   // Determine which plan should be active initially based on merchant preferences
   const activePlanIndex = getIndexOfActivePlan({
-    eligibilityPlans,
+    eligibilityPlans: plansToDisplay,
     suggestedPaymentPlan: suggestedPaymentPlan ?? 0,
   })
 
@@ -104,11 +111,11 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
   // Memoized array of eligible plan indices for keyboard navigation
   const eligiblePlanKeys = useMemo(
     () =>
-      eligibilityPlans.reduce<number[]>(
+      plansToDisplay.reduce<number[]>(
         (acc, plan, index) => (plan.eligible ? [...acc, index] : acc),
         [],
       ),
-    [eligibilityPlans],
+    [plansToDisplay],
   )
 
   /**
@@ -131,15 +138,15 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
   // Refs for managing focus on plan buttons during keyboard navigation
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
 
-  // Initialize button refs array when eligibility plans change
+  // Initialize button refs array when plans to display change
   useEffect(() => {
-    buttonRefs.current = buttonRefs.current.slice(0, eligibilityPlans.length)
-  }, [eligibilityPlans.length])
+    buttonRefs.current = buttonRefs.current.slice(0, plansToDisplay.length)
+  }, [plansToDisplay.length])
 
   // Announce plan changes to screen readers for accessibility
   useEffect(() => {
-    if (eligibilityPlans[current] && status === statusResponse.SUCCESS) {
-      const currentPlan = eligibilityPlans[current]
+    if (plansToDisplay[current] && status === statusResponse.SUCCESS) {
+      const currentPlan = plansToDisplay[current]
 
       const planDescription = getPlanDescription(currentPlan, intl)
       const announcementText = intl.formatMessage(
@@ -259,10 +266,10 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
     )
   }
 
-  // Hide widget if no eligible plans and merchant wants to hide it, or if API failed
+  // Hide widget if no plans to display (all hidden or none), no eligible plans when required, or API failed
   if (
     (hideIfNotEligible && eligiblePlans.length === 0) ||
-    eligibilityPlans.length === 0 ||
+    plansToDisplay.length === 0 ||
     status === statusResponse.FAILED
   ) {
     return null
@@ -348,7 +355,7 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
               defaultMessage: 'Options de paiement disponibles',
             })}
           >
-            {eligibilityPlans.map((eligibilityPlan, key) => {
+            {plansToDisplay.map((eligibilityPlan, key) => {
               const isCurrent = key === current
               const isEligible = eligibilityPlan.eligible
 
@@ -442,13 +449,13 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
               s.info,
               {
                 [cx(s.notEligible, STATIC_CUSTOMISATION_CLASSES.notEligibleOption)]:
-                  eligibilityPlans[current] && !eligibilityPlans[current].eligible,
+                  plansToDisplay[current] && !plansToDisplay[current].eligible,
               },
               STATIC_CUSTOMISATION_CLASSES.paymentInfo,
             )}
             id="payment-info-text"
           >
-            {eligibilityPlans.length !== 0 && paymentPlanInfoText(eligibilityPlans[current])}
+            {plansToDisplay.length !== 0 && paymentPlanInfoText(plansToDisplay[current])}
           </div>
         </div>
       </div>

--- a/src/hooks/useFetchEligibility.ts
+++ b/src/hooks/useFetchEligibility.ts
@@ -1,6 +1,12 @@
 import { useEffect, useState } from 'react'
 
-import { ApiConfig, ConfigPlan, EligibilityPlan, statusResponse } from '@/types'
+import {
+  ApiConfig,
+  ConfigPlan,
+  EligibilityPlan,
+  EligibilityPlanToDisplay,
+  statusResponse,
+} from '@/types'
 import { useSessionStorage } from 'hooks/useSessionStorage'
 import { fetchFromApi } from 'utils/fetch'
 import filterEligibility from 'utils/filterEligibility'
@@ -13,7 +19,7 @@ const useFetchEligibility = (
   customerBillingCountry?: string,
   customerShippingCountry?: string,
   merchantCoversAllFees?: boolean,
-): [EligibilityPlan[], statusResponse] => {
+): [EligibilityPlanToDisplay[], statusResponse] => {
   const [eligibility, setEligibility] = useState([] as EligibilityPlan[])
   const [status, setStatus] = useState(statusResponse.PENDING)
 

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -522,6 +522,38 @@ export const mockEligibilityPaymentPlanWithIneligiblePlan = [
   },
 ]
 
+// Same as mockEligibilityPaymentPlanWithIneligiblePlan but the 4x plan is ineligible due to
+// a country restriction (not available in Belgium) — the API returns no purchase_amount constraints,
+// so there is nothing useful to display grayed out → the plan should be hidden entirely.
+export const mockEligibilityWithHiddenPlan = [
+  ...mockEligibilityPaymentPlanWithIneligiblePlan.slice(0, 2),
+  {
+    deferred_days: 0,
+    deferred_months: 0,
+    eligible: false,
+    installments_count: 4,
+    purchase_amount: 45000,
+    reasons: { installments_count: 'not_allowed' },
+    // No constraints.purchase_amount → plan is hidden, not grayed out
+  },
+]
+
+// 4x plan is ineligible due to purchase_amount range — the API returns constraints.purchase_amount,
+// so the widget can display a meaningful "À partir de X€" condition → the plan should be grayed out.
+export const mockEligibilityWithGrayedOutPlan = [
+  ...mockEligibilityPaymentPlanWithIneligiblePlan.slice(0, 2),
+  {
+    constraints: { purchase_amount: { maximum: 15000, minimum: 5000 } },
+    deferred_days: 0,
+    deferred_months: 0,
+    eligible: false,
+    installments_count: 4,
+    purchase_amount: 45000,
+    reasons: { purchase_amount: 'invalid_value' },
+    // constraints.purchase_amount present → plan is grayed out, not hidden
+  },
+]
+
 export const mockPlansWithoutDeferred = mockPlansAllEligible.filter(
   (plan) => plan.deferred_days === 0 && plan.deferred_months === 0 && plan.installments_count >= 2,
 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export type ErrorResponse = {
 export type EligibilityPlanToDisplay = EligibilityPlan & {
   minAmount?: number
   maxAmount?: number
+  hidden?: boolean
 }
 
 export enum Locale {

--- a/src/utils/filterEligibility.ts
+++ b/src/utils/filterEligibility.ts
@@ -50,10 +50,18 @@ const filterEligibility = (
       )
     })
 
+    // Hide when there is no matching merchant config plan (installment count not available),
+    // or when the plan is ineligible and has no purchase_amount constraints from the API.
+    // The presence of constraints.purchase_amount means the plan is ineligible only due to
+    // price range — the widget can still show a meaningful "À partir de X€" condition.
+    // Without those constraints, there is nothing useful to display grayed out.
+    const hidden = !relatedConfigPlan || (!plan.eligible && !plan.constraints?.purchase_amount)
+
     return {
       ...plan,
       eligible: isPlanEligible(plan, relatedConfigPlan),
       ...getPaymentPlanBoundaries(plan, relatedConfigPlan),
+      hidden,
     }
   })
 }


### PR DESCRIPTION
When the eligibility API returns a plan with `eligible: false` and no `constraints.purchase_amount`, there is nothing useful to show the user (e.g. plan not available in their country). These plans are now hidden automatically instead of being displayed grayed out.

[Fixes](https://linear.app/almapay/issue/MXP-4646/add-new-hideineligibleplansoption-to-the-widget)

This example of the widget bellow shows the new hideIfNotEligible behavior for non-price-range ineligibility reasons. 
The 6x plan is returned by the API as eligible: false with reasons: `{ installments_count: "invalid_value" }`, meaning it is not part of the merchant's contract (not available in their country or not activated on their account). 

Unlike price-range ineligibility (where the plan is grayed out with an amount hint), this type of ineligibility has no meaningful context to show the user, so the plan is hidden entirely rather than displayed in a degraded state.

<img width="1464" height="656" alt="image" src="https://github.com/user-attachments/assets/c967bab0-7ece-4973-9a2a-dd11e9dc9288" />
