### PR TITLE
Make info line clickable

### DIFF
--- a/src/Widgets/PaymentPlans/__tests__/InfoLink.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/InfoLink.test.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable testing-library/no-unnecessary-act */
 import React from 'react'
 
-import { act, screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 
@@ -30,19 +29,14 @@ describe('Payment info line (know more link)', () => {
   })
 
   const renderWithKnowMoreHint = async () => {
-    await act(async () => {
-      render(
-        <PaymentPlanWidget
-          purchaseAmount={40000}
-          suggestedPaymentPlan={10}
-          apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
-        />,
-      )
-    })
-
-    await act(async () => {
-      await screen.findByTestId('widget-container')
-    })
+    render(
+      <PaymentPlanWidget
+        purchaseAmount={40000}
+        suggestedPaymentPlan={10}
+        apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
+      />,
+    )
+    await screen.findByTestId('widget-container')
   }
 
   it('exposes the info line as an accessible button when the plan is eligible', async () => {
@@ -63,13 +57,9 @@ describe('Payment info line (know more link)', () => {
     expect(screen.queryByTestId('modal-container')).not.toBeInTheDocument()
 
     const infoText = document.getElementById('payment-info-text') as HTMLElement
-    await act(async () => {
-      await user.click(infoText)
-    })
+    await user.click(infoText)
 
-    await waitFor(() => {
-      expect(screen.getByTestId('modal-container')).toBeInTheDocument()
-    })
+    expect(await screen.findByTestId('modal-container')).toBeInTheDocument()
   })
 
   it('opens the modal when the info line is activated with the keyboard', async () => {
@@ -77,17 +67,12 @@ describe('Payment info line (know more link)', () => {
     await renderWithKnowMoreHint()
 
     const infoText = document.getElementById('payment-info-text') as HTMLElement
-    await act(async () => {
-      infoText.focus()
-    })
+    infoText.focus()
     expect(infoText).toHaveFocus()
 
-    await act(async () => {
-      await user.keyboard('{Enter}')
-    })
-    await waitFor(() => {
-      expect(screen.getByTestId('modal-container')).toBeInTheDocument()
-    })
+    await user.keyboard('{Enter}')
+
+    expect(await screen.findByTestId('modal-container')).toBeInTheDocument()
   })
 
   it('has no accessibility violations with the clickable info line', async () => {

--- a/src/Widgets/PaymentPlans/__tests__/InfoLink.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/InfoLink.test.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable testing-library/no-unnecessary-act */
+import React from 'react'
+
+import { act, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+
+import { ApiMode } from '@/consts'
+import render from '@/test'
+import { mockButtonPlans } from '@/test/fixtures'
+import PaymentPlanWidget from 'Widgets/PaymentPlans'
+
+// Mock fetch to avoid real API calls during tests
+jest.mock('utils/fetch', () => ({
+  fetchFromApi: async () => mockButtonPlans,
+}))
+
+describe('Payment info line (know more link)', () => {
+  beforeEach(() => {
+    // Mock requestAnimationFrame to avoid timing issues with react-modal
+    global.requestAnimationFrame = jest.fn((cb) => {
+      setTimeout(cb, 0)
+      return 0
+    })
+    global.cancelAnimationFrame = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const renderWithKnowMoreHint = async () => {
+    await act(async () => {
+      render(
+        <PaymentPlanWidget
+          purchaseAmount={40000}
+          suggestedPaymentPlan={10}
+          apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
+        />,
+      )
+    })
+
+    await act(async () => {
+      await screen.findByTestId('widget-container')
+    })
+  }
+
+  it('exposes the info line as an accessible button when the plan is eligible', async () => {
+    await renderWithKnowMoreHint()
+
+    const infoText = document.getElementById('payment-info-text')
+    expect(infoText).toBeInTheDocument()
+    expect(infoText).toHaveAttribute('role', 'button')
+    expect(infoText).toHaveAttribute('tabindex', '0')
+    expect(infoText).toHaveAttribute('aria-haspopup', 'dialog')
+    expect(infoText).toHaveTextContent(/en savoir plus/i)
+  })
+
+  it('opens the modal when the info line is clicked', async () => {
+    const user = userEvent.setup()
+    await renderWithKnowMoreHint()
+
+    expect(screen.queryByTestId('modal-container')).not.toBeInTheDocument()
+
+    const infoText = document.getElementById('payment-info-text') as HTMLElement
+    await act(async () => {
+      await user.click(infoText)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-container')).toBeInTheDocument()
+    })
+  })
+
+  it('opens the modal when the info line is activated with the keyboard', async () => {
+    const user = userEvent.setup()
+    await renderWithKnowMoreHint()
+
+    const infoText = document.getElementById('payment-info-text') as HTMLElement
+    await act(async () => {
+      infoText.focus()
+    })
+    expect(infoText).toHaveFocus()
+
+    await act(async () => {
+      await user.keyboard('{Enter}')
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-container')).toBeInTheDocument()
+    })
+  })
+
+  it('has no accessibility violations with the clickable info line', async () => {
+    const { container } = render(
+      <PaymentPlanWidget
+        purchaseAmount={40000}
+        suggestedPaymentPlan={10}
+        apiData={{ domain: ApiMode.TEST, merchantId: '11gKoO333vEXacMNMUMUSc4c4g68g2Les4' }}
+      />,
+    )
+
+    await screen.findByTestId('widget-container')
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -279,12 +279,31 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
    * Handle opening the eligibility modal
    * Prevents default behavior and only opens if there are eligible plans
    */
-  const handleOpenModal = (
-    e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>,
-  ) => {
+  const handleOpenModal = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.preventDefault()
     if (eligiblePlans.length > 0) {
       openModal()
+    }
+  }
+
+  const currentPlanToDisplay = plansToDisplay[current]
+
+  // Plans with more than 4 installments show a "know more" hint that must open the modal.
+  const isInfoClickable =
+    eligiblePlans.length > 0 &&
+    Boolean(currentPlanToDisplay?.eligible) &&
+    currentPlanToDisplay.installments_count > 4
+
+  const infoInteractiveProps: React.HTMLAttributes<HTMLDivElement> = {}
+  if (isInfoClickable) {
+    infoInteractiveProps.role = 'button'
+    infoInteractiveProps.tabIndex = 0
+    infoInteractiveProps['aria-haspopup'] = 'dialog'
+    infoInteractiveProps.onClick = handleOpenModal
+    infoInteractiveProps.onKeyDown = (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        handleOpenModal(e)
+      }
     }
   }
 
@@ -449,13 +468,15 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
               s.info,
               {
                 [cx(s.notEligible, STATIC_CUSTOMISATION_CLASSES.notEligibleOption)]:
-                  plansToDisplay[current] && !plansToDisplay[current].eligible,
+                  currentPlanToDisplay && !currentPlanToDisplay.eligible,
+                [s.clickable]: isInfoClickable,
               },
               STATIC_CUSTOMISATION_CLASSES.paymentInfo,
             )}
             id="payment-info-text"
+            {...infoInteractiveProps}
           >
-            {plansToDisplay.length !== 0 && paymentPlanInfoText(plansToDisplay[current])}
+            {plansToDisplay.length !== 0 && paymentPlanInfoText(currentPlanToDisplay)}
           </div>
         </div>
       </div>

--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useEffect, useMemo, useRef, useState } from '
 import cx from 'classnames'
 import { useIntl } from 'react-intl'
 
-import { ApiConfig, Card, ConfigPlan, statusResponse } from '@/types'
+import { ApiConfig, Card, ConfigPlan, EligibilityPlanToDisplay, statusResponse } from '@/types'
 import { AlmaLogo } from 'assets/almaLogo'
 import Loader from 'components/Loader'
 import { useAnimationInstructions } from 'hooks/useAnimationInstructions'
@@ -286,12 +286,12 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
     }
   }
 
-  const currentPlanToDisplay = plansToDisplay[current]
+  const currentPlanToDisplay: EligibilityPlanToDisplay | undefined = plansToDisplay[current]
 
   // Plans with more than 4 installments show a "know more" hint that must open the modal.
   const isInfoClickable =
     eligiblePlans.length > 0 &&
-    Boolean(currentPlanToDisplay?.eligible) &&
+    !!currentPlanToDisplay?.eligible &&
     currentPlanToDisplay.installments_count > 4
 
   const infoInteractiveProps: React.HTMLAttributes<HTMLDivElement> = {}
@@ -468,7 +468,7 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
               s.info,
               {
                 [cx(s.notEligible, STATIC_CUSTOMISATION_CLASSES.notEligibleOption)]:
-                  currentPlanToDisplay && !currentPlanToDisplay.eligible,
+                  !currentPlanToDisplay?.eligible,
                 [s.clickable]: isInfoClickable,
               },
               STATIC_CUSTOMISATION_CLASSES.paymentInfo,
@@ -476,7 +476,7 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
             id="payment-info-text"
             {...infoInteractiveProps}
           >
-            {plansToDisplay.length !== 0 && paymentPlanInfoText(currentPlanToDisplay)}
+            {currentPlanToDisplay && paymentPlanInfoText(currentPlanToDisplay)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
When the widget displays more than x4 installments, it also displays an info text. It looks like a link but does nothing.
This PR makes it a link that opens the modal.

<img width="395" height="109" alt="image" src="https://github.com/user-attachments/assets/90c35460-a0d6-44f1-9614-c07788d3a606" />

https://github.com/user-attachments/assets/bd3a2d4d-405e-4f5a-91cc-0de7f323c559

