### PR TITLE
fix(fonts): serve woff2 for venn typeface

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -38,9 +38,8 @@
 @font-face {
   font-family: Venn;
   src:
-    url('https://cdn.almapay.com/fonts/Venn/Venn-Bold.eot') format('embedded-opentype'),
-    url('https://cdn.almapay.com/fonts/Venn/Venn-Bold.woff') format('woff'),
-    url('https://cdn.almapay.com/fonts/Venn/Venn-Bold.ttf') format('truetype');
+    url('https://cdn.almapay.com/fonts/Venn/Venn-Bold.woff2') format('woff2'),
+    url('https://cdn.almapay.com/fonts/Venn/Venn-Bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
@@ -49,9 +48,8 @@
 @font-face {
   font-family: Venn;
   src:
-    url('https://cdn.almapay.com/fonts/Venn/Venn-Regular.eot?#iefix') format('embedded-opentype'),
-    url('https://cdn.almapay.com/fonts/Venn/Venn-Regular.woff') format('woff'),
-    url('https://cdn.almapay.com/fonts/Venn/Venn-Regular.ttf') format('truetype');
+    url('https://cdn.almapay.com/fonts/Venn/Venn-Regular.woff2') format('woff2'),
+    url('https://cdn.almapay.com/fonts/Venn/Venn-Regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
   font-display: swap;


### PR DESCRIPTION
## Summary

Switch the Venn `@font-face` sources to WOFF2 (with a WOFF fallback), dropping the unused EOT/TTF entries. Font URLs stay on `cdn.almapay.com` — nothing moves.

Fixes [MXP-5033](https://linear.app/almapay/issue/MXP-5033/optimise-venn-web-font-loading-in-the-widget)

## Why WOFF2-over-CDN, not bundling locally

PR #108 (2023) deliberately moved Venn/Argent off the npm package and onto `cdn.almapay.com` to shrink the widget bundle and standardize font delivery across Alma's properties. Re-bundling locally would reverse that tradeoff to fix a merchant-reported perf issue that trace data shows isn't actually caused by bundle size or a slow font download (~4ms once requested). So we kept the CDN as the source of truth and only fixed the format being served.

## The CDN already serves WOFF2

`cdn.almapay.com/fonts/Venn/*.woff2` already exists and responds correctly (`content-type: font/woff2`, `Access-Control-Allow-Origin: *`, `cache-control: public, max-age=2630000`). The gap was never the CDN — `main.css` simply never listed `.woff2` in `src:` (it was generated as an unused artifact historically, then deleted outright in PR #108). This change just wires the existing file back in and gets a smaller payload for free.

## Why not preconnect/preload

The merchant's audit asked for a `preconnect`/`preload` hint. We didn't pursue it: the widget's JS only runs after the merchant's own `<link rel="stylesheet">` has already been discovered and fetched, so a hint injected from our script arrives too late in the critical chain to help. A hint that would actually help has to live in the merchant's own `<head>`, which we don't control.

## Testing

- `npm run lint` — passes
- `npm run test` — 246/246 tests pass
- Verified the CDN response headers directly (status, content-type, CORS, cache-control) for all four font files