### PR TITLE
Feature/mxp 5081 update paymentplans component

### DIFF
--- a/src/Widgets/PaymentPlans/__tests__/Credit.test.tsx
+++ b/src/Widgets/PaymentPlans/__tests__/Credit.test.tsx
@@ -64,7 +64,49 @@ describe('PaymentPlan has credit', () => {
     await userEvent.hover(screen.getByText('3x'))
     expect(screen.getByText(/151,35 € puis 2 x 150,00 €/)).toBeInTheDocument()
     await userEvent.hover(screen.getByText('10x'))
+    expect(screen.getByText(/47,73 € puis 9 x 47,66 €/)).toBeInTheDocument()
     expect(screen.getByText(/Cliquez pour en savoir plus/)).toBeInTheDocument()
+  })
+
+  const infoLine = () => document.getElementById('payment-info-text') as HTMLElement
+
+  it('shows the breakdown and the know-more line for a credit plan', async () => {
+    await setUpTest()
+
+    await userEvent.hover(screen.getByText('10x'))
+
+    expect(infoLine()).toHaveTextContent('47,73 € puis 9 x 47,66 €')
+    expect(infoLine()).toHaveTextContent('Cliquez pour en savoir plus')
+    expect(infoLine()).toHaveAttribute('role', 'button')
+  })
+
+  it('shows the know-more line for a P2X-P4X plan, which had none before', async () => {
+    await setUpTest()
+
+    await userEvent.hover(screen.getByText('3x'))
+
+    expect(infoLine()).toHaveTextContent('151,35 € puis 2 x 150,00 €')
+    expect(infoLine()).toHaveTextContent('Cliquez pour en savoir plus')
+  })
+
+  it('keeps the deferred wording and adds the know-more line for a deferred P1X plan', async () => {
+    await setUpTest()
+
+    await userEvent.hover(screen.getByText('M+1'))
+
+    expect(infoLine()).toHaveTextContent('450,00 € à payer le 21 novembre 2021')
+    expect(infoLine()).toHaveTextContent('Cliquez pour en savoir plus')
+    expect(infoLine()).toHaveAttribute('role', 'button')
+  })
+
+  it('leaves a non-deferred P1X plan with a single, non-clickable line', async () => {
+    await setUpTest()
+
+    await userEvent.hover(screen.getByText('Payer maintenant'))
+
+    expect(infoLine()).toHaveTextContent('Payer maintenant 450,00 €')
+    expect(infoLine()).not.toHaveTextContent('Cliquez pour en savoir plus')
+    expect(infoLine()).not.toHaveAttribute('role', 'button')
   })
 
   it('stops iterating when an element has been hovered', async () => {

--- a/src/Widgets/PaymentPlans/index.tsx
+++ b/src/Widgets/PaymentPlans/index.tsx
@@ -16,6 +16,7 @@ import {
   paymentPlanInfoText,
   paymentPlanShorthandName,
 } from 'utils/paymentPlanStrings'
+import { requiresLegalDisclosure } from 'utils/regulatoryFigures'
 import STATIC_CUSTOMISATION_CLASSES from 'Widgets//PaymentPlans/classNames.const'
 import EligibilityModal from 'Widgets/EligibilityModal'
 import s from 'Widgets/PaymentPlans/PaymentPlans.module.css'
@@ -288,11 +289,12 @@ const PaymentPlanWidget: FunctionComponent<Props> = ({
 
   const currentPlanToDisplay: EligibilityPlanToDisplay | undefined = plansToDisplay[current]
 
-  // Plans with more than 4 installments show a "know more" hint that must open the modal.
+  // Every plan requiring legal disclosure shows a "know more" hint that must open the modal —
+  // P2X-P12X and deferred P1X, so no longer just credit plans.
   const isInfoClickable =
     eligiblePlans.length > 0 &&
     !!currentPlanToDisplay?.eligible &&
-    currentPlanToDisplay.installments_count > 4
+    requiresLegalDisclosure(currentPlanToDisplay)
 
   const infoInteractiveProps: React.HTMLAttributes<HTMLDivElement> = {}
   if (isInfoClickable) {

--- a/src/components/Installments/LegalMentions/__tests__/LegalMentions.test.tsx
+++ b/src/components/Installments/LegalMentions/__tests__/LegalMentions.test.tsx
@@ -41,7 +41,7 @@ describe('standard PNX/Credit variant', () => {
 
     const legalMentions = screen.getByTestId('legal-mentions')
     expect(legalMentions).toHaveTextContent(
-      "Crédit de 428,95 € au taux débiteur fixe de 17,2 % sur 9 mois. Permettant, avec un acompte de 47,69 €, de financer un achat de 450,00 €.",
+      'Crédit de 428,95 € au taux débiteur fixe de 17,2 % sur 9 mois. Permettant, avec un acompte de 47,69 €, de financer un achat de 450,00 €.',
     )
     expect(legalMentions).toHaveTextContent(DISCLAIMER)
     expect(legalMentions).not.toHaveTextContent('incluant des frais')

--- a/src/components/Installments/LegalMentions/index.tsx
+++ b/src/components/Installments/LegalMentions/index.tsx
@@ -88,19 +88,19 @@ const LegalMentions = ({ currentPlan }: LegalMentionsProps) => {
     const deferredDuration =
       deferredMonths > 0
         ? formatMessage(
-          {
-            id: 'payment-plan-strings.deferred.months',
-            defaultMessage: '{months, number} {months, plural, one {mois} other {mois}}',
-          },
-          { months: deferredMonths },
-        )
+            {
+              id: 'payment-plan-strings.deferred.months',
+              defaultMessage: '{months, number} {months, plural, one {mois} other {mois}}',
+            },
+            { months: deferredMonths },
+          )
         : formatMessage(
-          {
-            id: 'payment-plan-strings.deferred.days',
-            defaultMessage: '{days, number} {days, plural, one {jour} other {jours}}',
-          },
-          { days: deferredDays },
-        )
+            {
+              id: 'payment-plan-strings.deferred.days',
+              defaultMessage: '{days, number} {days, plural, one {jour} other {jours}}',
+            },
+            { days: deferredDays },
+          )
 
     const totalDue = formatPrice(getTotalPurchaseAmount(currentPlan), {
       minimumFractionDigits: 2,

--- a/src/intl/messages.json
+++ b/src/intl/messages.json
@@ -40,7 +40,6 @@
   "legal-mentions.pnx-with-fees": "Crédit de {financedAmount} au taux débiteur fixe de {annualPercentageRate} sur {creditDurationInMonths} mois. Permettant, avec un acompte de {initialDeposit}, incluant des frais de {fees}, de financer un achat de {purchaseAmount}. {disclaimer}",
   "payment-plan-strings.credit": "Cliquez pour en savoir plus",
   "payment-plan-strings.day-abbreviation": "J{deferredDays}",
-  "payment-plan-strings.default-message": "Payez en plusieurs fois avec Alma",
   "payment-plan-strings.deferred": "{totalAmount} à payer le {dueDate}",
   "payment-plan-strings.deferred.days": "{days, number} {days, plural, one {jour} other {jours}}",
   "payment-plan-strings.deferred.months": "{months, number} {months, plural, one {mois} other {mois}}",

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -177,17 +177,6 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
     )
   }
 
-  if (installmentsCount <= 0) {
-    return (
-      <p>
-        <FormattedMessage
-          id="payment-plan-strings.default-message"
-          defaultMessage="Payez en plusieurs fois avec Alma"
-        />
-      </p>
-    )
-  }
-
   if (deferredDaysCount !== 0 && installmentsCount === 1) {
     return (
       <>
@@ -319,19 +308,19 @@ export const getPlanDescription = (plan: EligibilityPlanToDisplay, intl: IntlSha
         deferredTime:
           plan.deferred_months > 0
             ? intl.formatMessage(
-              {
-                id: 'payment-plan-strings.deferred.months',
-                defaultMessage: '{months, number} {months, plural, one {mois} other {mois}}',
-              },
-              { months: plan.deferred_months },
-            )
+                {
+                  id: 'payment-plan-strings.deferred.months',
+                  defaultMessage: '{months, number} {months, plural, one {mois} other {mois}}',
+                },
+                { months: plan.deferred_months },
+              )
             : intl.formatMessage(
-              {
-                id: 'payment-plan-strings.deferred.days',
-                defaultMessage: '{days, number} {days, plural, one {jour} other {jours}}',
-              },
-              { days: plan.deferred_days },
-            ),
+                {
+                  id: 'payment-plan-strings.deferred.days',
+                  defaultMessage: '{days, number} {days, plural, one {jour} other {jours}}',
+                },
+                { days: plan.deferred_days },
+              ),
       },
     )
   }

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -175,7 +175,20 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
     throw Error(
       `No payment plan provided for payment in ${installmentsCount} installments. Please contact us if you see this error.`,
     )
-  } else if (deferredDaysCount !== 0 && installmentsCount === 1) {
+  }
+
+  if (installmentsCount <= 0) {
+    return (
+      <p>
+        <FormattedMessage
+          id="payment-plan-strings.default-message"
+          defaultMessage="Payez en plusieurs fois avec Alma"
+        />
+      </p>
+    )
+  }
+
+  if (deferredDaysCount !== 0 && installmentsCount === 1) {
     return (
       <>
         <p>
@@ -205,18 +218,41 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
         {knowMoreLine(payment)}
       </>
     )
-  } else if (installmentsCount > 0) {
-    const areInstallmentsOfSameAmount = paymentPlan?.every(
-      (installment, index) =>
-        index === 0 || installment.total_amount === paymentPlan[0].total_amount,
-    )
+  }
 
-    if (isP1X(payment)) {
-      return (
+  if (isP1X(payment)) {
+    return (
+      <p>
+        <FormattedMessage
+          id="payment-plan-strings.pay-now"
+          defaultMessage="Payer maintenant {totalAmount}"
+          values={{
+            totalAmount: (
+              <FormattedNumber
+                value={priceFromCents(paymentPlan[0].total_amount)}
+                style="currency"
+                currency="EUR"
+              />
+            ),
+            installmentsCount,
+          }}
+        />
+        {withNoFee(payment)}
+      </p>
+    )
+  }
+
+  const areInstallmentsOfSameAmount = paymentPlan.every(
+    (installment, index) => index === 0 || installment.total_amount === paymentPlan[0].total_amount,
+  )
+
+  if (areInstallmentsOfSameAmount) {
+    return (
+      <>
         <p>
           <FormattedMessage
-            id="payment-plan-strings.pay-now"
-            defaultMessage="Payer maintenant {totalAmount}"
+            id="payment-plan-strings.multiple-installments-same-amount"
+            defaultMessage="{installmentsCount} x {totalAmount}"
             values={{
               totalAmount: (
                 <FormattedNumber
@@ -230,71 +266,39 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
           />
           {withNoFee(payment)}
         </p>
-      )
-    }
-
-    if (areInstallmentsOfSameAmount) {
-      return (
-        <>
-          <p>
-            <FormattedMessage
-              id="payment-plan-strings.multiple-installments-same-amount"
-              defaultMessage="{installmentsCount} x {totalAmount}"
-              values={{
-                totalAmount: (
-                  <FormattedNumber
-                    value={priceFromCents(paymentPlan[0].total_amount)}
-                    style="currency"
-                    currency="EUR"
-                  />
-                ),
-                installmentsCount,
-              }}
-            />
-            {withNoFee(payment)}
-          </p>
-          {knowMoreLine(payment)}
-        </>
-      )
-    }
-
-    return (
-      <>
-        <p>
-          <FormattedMessage
-            id="payment-plan-strings.multiple-installments"
-            defaultMessage="{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}}}"
-            values={{
-              firstInstallmentAmount: (
-                <FormattedNumber
-                  value={priceFromCents(paymentPlan[0].total_amount)}
-                  style="currency"
-                  currency="EUR"
-                />
-              ),
-              numberOfRemainingInstallments: installmentsCount - 1,
-              othersInstallmentAmount: (
-                <FormattedNumber
-                  value={priceFromCents(paymentPlan[1].total_amount)}
-                  style="currency"
-                  currency="EUR"
-                />
-              ),
-            }}
-          />
-          {withNoFee(payment)}
-        </p>
         {knowMoreLine(payment)}
       </>
     )
   }
+
   return (
-    <p>
-      <FormattedMessage
-        id="payment-plan-strings.default-message"
-        defaultMessage="Payez en plusieurs fois avec Alma"
-      />
-    </p>
+    <>
+      <p>
+        <FormattedMessage
+          id="payment-plan-strings.multiple-installments"
+          defaultMessage="{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}}}"
+          values={{
+            firstInstallmentAmount: (
+              <FormattedNumber
+                value={priceFromCents(paymentPlan[0].total_amount)}
+                style="currency"
+                currency="EUR"
+              />
+            ),
+            numberOfRemainingInstallments: installmentsCount - 1,
+            othersInstallmentAmount: (
+              <FormattedNumber
+                value={priceFromCents(paymentPlan[1].total_amount)}
+                style="currency"
+                currency="EUR"
+              />
+            ),
+          }}
+        />
+        {withNoFee(payment)}
+      </p>
+      {knowMoreLine(payment)}
+    </>
   )
 }
 
@@ -315,19 +319,19 @@ export const getPlanDescription = (plan: EligibilityPlanToDisplay, intl: IntlSha
         deferredTime:
           plan.deferred_months > 0
             ? intl.formatMessage(
-                {
-                  id: 'payment-plan-strings.deferred.months',
-                  defaultMessage: '{months, number} {months, plural, one {mois} other {mois}}',
-                },
-                { months: plan.deferred_months },
-              )
+              {
+                id: 'payment-plan-strings.deferred.months',
+                defaultMessage: '{months, number} {months, plural, one {mois} other {mois}}',
+              },
+              { months: plan.deferred_months },
+            )
             : intl.formatMessage(
-                {
-                  id: 'payment-plan-strings.deferred.days',
-                  defaultMessage: '{days, number} {days, plural, one {jour} other {jours}}',
-                },
-                { days: plan.deferred_days },
-              ),
+              {
+                id: 'payment-plan-strings.deferred.days',
+                defaultMessage: '{days, number} {days, plural, one {jour} other {jours}}',
+              },
+              { days: plan.deferred_days },
+            ),
       },
     )
   }

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -6,7 +6,7 @@ import { FormattedDate, FormattedMessage, FormattedNumber, IntlShape } from 'rea
 import { EligibilityPlanToDisplay } from '@/types'
 import { isP1X, priceFromCents } from '@/utils'
 import s from '@/utils/paymentPlanStrings.module.css'
-import { isPayLater } from '@/utils/regulatoryFigures'
+import { isPayLater, requiresLegalDisclosure } from '@/utils/regulatoryFigures'
 
 export const paymentPlanShorthandName = (payment: EligibilityPlanToDisplay): ReactNode => {
   const {
@@ -107,6 +107,19 @@ const withNoFee = (payment: EligibilityPlanToDisplay) => {
   }
 }
 
+const knowMoreLine = (payment: EligibilityPlanToDisplay): ReactNode => {
+  if (!payment.eligible || !requiresLegalDisclosure(payment)) return null
+  return (
+    <p className={s.openModalInfo}>
+      <FormattedMessage
+        id="payment-plan-strings.credit"
+        defaultMessage="Cliquez pour en savoir plus"
+        description="Link to credit details"
+      />
+    </p>
+  )
+}
+
 export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNode => {
   const {
     deferred_days: deferredDays,
@@ -164,30 +177,33 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
     )
   } else if (deferredDaysCount !== 0 && installmentsCount === 1) {
     return (
-      <p>
-        <FormattedMessage
-          id="payment-plan-strings.deferred"
-          defaultMessage="{totalAmount} à payer le {dueDate}"
-          values={{
-            totalAmount: (
-              <FormattedNumber
-                value={priceFromCents(paymentPlan[0].total_amount)}
-                style="currency"
-                currency="EUR"
-              />
-            ),
-            dueDate: (
-              <FormattedDate
-                value={secondsToMilliseconds(paymentPlan[0].due_date)}
-                day="numeric"
-                month="long"
-                year="numeric"
-              />
-            ),
-          }}
-        />
-        {withNoFee(payment)}
-      </p>
+      <>
+        <p>
+          <FormattedMessage
+            id="payment-plan-strings.deferred"
+            defaultMessage="{totalAmount} à payer le {dueDate}"
+            values={{
+              totalAmount: (
+                <FormattedNumber
+                  value={priceFromCents(paymentPlan[0].total_amount)}
+                  style="currency"
+                  currency="EUR"
+                />
+              ),
+              dueDate: (
+                <FormattedDate
+                  value={secondsToMilliseconds(paymentPlan[0].due_date)}
+                  day="numeric"
+                  month="long"
+                  year="numeric"
+                />
+              ),
+            }}
+          />
+          {withNoFee(payment)}
+        </p>
+        {knowMoreLine(payment)}
+      </>
     )
   } else if (installmentsCount > 0) {
     const areInstallmentsOfSameAmount = paymentPlan?.every(
@@ -195,87 +211,84 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
         index === 0 || installment.total_amount === paymentPlan[0].total_amount,
     )
 
-    if (installmentsCount > 4) {
-      return (
-        <p className={s.openModalInfo}>
-          <FormattedMessage
-            id="payment-plan-strings.credit"
-            defaultMessage="Cliquez pour en savoir plus"
-            description="Link to credit details"
-          />
-        </p>
-      )
-    }
-
     if (isP1X(payment)) {
       return (
-        <p>
-          <FormattedMessage
-            id="payment-plan-strings.pay-now"
-            defaultMessage="Payer maintenant {totalAmount}"
-            values={{
-              totalAmount: (
-                <FormattedNumber
-                  value={priceFromCents(paymentPlan[0].total_amount)}
-                  style="currency"
-                  currency="EUR"
-                />
-              ),
-              installmentsCount,
-            }}
-          />
-          {withNoFee(payment)}
-        </p>
+        <>
+          <p>
+            <FormattedMessage
+              id="payment-plan-strings.pay-now"
+              defaultMessage="Payer maintenant {totalAmount}"
+              values={{
+                totalAmount: (
+                  <FormattedNumber
+                    value={priceFromCents(paymentPlan[0].total_amount)}
+                    style="currency"
+                    currency="EUR"
+                  />
+                ),
+                installmentsCount,
+              }}
+            />
+            {withNoFee(payment)}
+          </p>
+          {knowMoreLine(payment)}
+        </>
       )
     }
 
     if (areInstallmentsOfSameAmount) {
       return (
+        <>
+          <p>
+            <FormattedMessage
+              id="payment-plan-strings.multiple-installments-same-amount"
+              defaultMessage="{installmentsCount} x {totalAmount}"
+              values={{
+                totalAmount: (
+                  <FormattedNumber
+                    value={priceFromCents(paymentPlan[0].total_amount)}
+                    style="currency"
+                    currency="EUR"
+                  />
+                ),
+                installmentsCount,
+              }}
+            />
+            {withNoFee(payment)}
+          </p>
+          {knowMoreLine(payment)}
+        </>
+      )
+    }
+
+    return (
+      <>
         <p>
           <FormattedMessage
-            id="payment-plan-strings.multiple-installments-same-amount"
-            defaultMessage="{installmentsCount} x {totalAmount}"
+            id="payment-plan-strings.multiple-installments"
+            defaultMessage="{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}}}"
             values={{
-              totalAmount: (
+              firstInstallmentAmount: (
                 <FormattedNumber
                   value={priceFromCents(paymentPlan[0].total_amount)}
                   style="currency"
                   currency="EUR"
                 />
               ),
-              installmentsCount,
+              numberOfRemainingInstallments: installmentsCount - 1,
+              othersInstallmentAmount: (
+                <FormattedNumber
+                  value={priceFromCents(paymentPlan[1].total_amount)}
+                  style="currency"
+                  currency="EUR"
+                />
+              ),
             }}
           />
           {withNoFee(payment)}
         </p>
-      )
-    }
-
-    return (
-      <p>
-        <FormattedMessage
-          id="payment-plan-strings.multiple-installments"
-          defaultMessage="{numberOfRemainingInstallments, plural, one {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}} other {{firstInstallmentAmount} puis {numberOfRemainingInstallments} x {othersInstallmentAmount}}}"
-          values={{
-            firstInstallmentAmount: (
-              <FormattedNumber
-                value={priceFromCents(paymentPlan[0].total_amount)}
-                style="currency"
-                currency="EUR"
-              />
-            ),
-            numberOfRemainingInstallments: installmentsCount - 1,
-            othersInstallmentAmount: (
-              <FormattedNumber
-                value={priceFromCents(paymentPlan[1].total_amount)}
-                style="currency"
-                currency="EUR"
-              />
-            ),
-          }}
-        />
-        {withNoFee(payment)}
-      </p>
+        {knowMoreLine(payment)}
+      </>
     )
   }
   return (

--- a/src/utils/paymentPlanStrings.tsx
+++ b/src/utils/paymentPlanStrings.tsx
@@ -213,26 +213,23 @@ export const paymentPlanInfoText = (payment: EligibilityPlanToDisplay): ReactNod
 
     if (isP1X(payment)) {
       return (
-        <>
-          <p>
-            <FormattedMessage
-              id="payment-plan-strings.pay-now"
-              defaultMessage="Payer maintenant {totalAmount}"
-              values={{
-                totalAmount: (
-                  <FormattedNumber
-                    value={priceFromCents(paymentPlan[0].total_amount)}
-                    style="currency"
-                    currency="EUR"
-                  />
-                ),
-                installmentsCount,
-              }}
-            />
-            {withNoFee(payment)}
-          </p>
-          {knowMoreLine(payment)}
-        </>
+        <p>
+          <FormattedMessage
+            id="payment-plan-strings.pay-now"
+            defaultMessage="Payer maintenant {totalAmount}"
+            values={{
+              totalAmount: (
+                <FormattedNumber
+                  value={priceFromCents(paymentPlan[0].total_amount)}
+                  style="currency"
+                  currency="EUR"
+                />
+              ),
+              installmentsCount,
+            }}
+          />
+          {withNoFee(payment)}
+        </p>
       )
     }
 


### PR DESCRIPTION
Under DCC2, every plan that carries a legal disclosure (Pay Later (deferred P1X), PNX (P2X–P4X) and credit (P5X+))  needs a way for the customer to reach the modal holding those legal mentions. Today only credit plans offer one, and they do it by replacing the instalment breakdown with the "Cliquez pour en savoir plus" line: the customer trades seeing the amounts for seeing the link.

This PR makes the know-more line an addition rather than a substitution, and gates it on requiresLegalDisclosure instead of installments_count > 4, so the set of plans that advertise the modal matches the set that legally needs it.